### PR TITLE
Add UploadThing storage manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@langchain/langgraph": "^1.0.2",
     "@next-auth/mongodb-adapter": "^1.1.3",
     "@radix-ui/react-switch": "^1.2.6",
+    "@uploadthing/react": "^7.3.3",
     "bad-words": "^4.0.0",
     "browser-image-compression": "^2.0.2",
     "chart.js": "^4.5.0",
@@ -49,7 +50,8 @@
     "react-syntax-highlighter": "^15.6.6",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
-    "swiper": "^12.0.3"
+    "swiper": "^12.0.3",
+    "uploadthing": "^7.7.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@radix-ui/react-switch':
         specifier: ^1.2.6
         version: 1.2.6(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@uploadthing/react':
+        specifier: ^7.3.3
+        version: 7.3.3(next@15.5.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(uploadthing@7.7.4(next@15.5.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tailwindcss@4.1.15))
       bad-words:
         specifier: ^4.0.0
         version: 4.0.0
@@ -104,6 +107,9 @@ importers:
       swiper:
         specifier: ^12.0.3
         version: 12.0.3
+      uploadthing:
+        specifier: ^7.7.4
+        version: 7.7.4(next@15.5.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tailwindcss@4.1.15)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -154,6 +160,11 @@ packages:
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
+
+  '@effect/platform@0.90.3':
+    resolution: {integrity: sha512-XvQ37yzWQKih4Du2CYladd1i/MzqtgkTPNCaN6Ku6No4CK83hDtXIV/rP03nEoBg2R3Pqgz6gGWmE2id2G81HA==}
+    peerDependencies:
+      effect: ^3.17.7
 
   '@emnapi/core@1.6.0':
     resolution: {integrity: sha512-zq/ay+9fNIJJtJiZxdTnXS20PllcYMX3OE23ESc4HK/bdYu3cOWYVhsOhVnXALfU/uqJIxn5NBPd9z4v+SfoSg==}
@@ -424,6 +435,36 @@ packages:
   '@mongodb-js/saslprep@1.3.2':
     resolution: {integrity: sha512-QgA5AySqB27cGTXBFmnpifAi7HxoGUeezwo6p9dI03MuDB6Pp33zgclqVb6oVK3j6I9Vesg0+oojW2XxB59SGg==}
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -502,6 +543,10 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@opentelemetry/semantic-conventions@1.39.0':
+    resolution: {integrity: sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==}
+    engines: {node: '>=14'}
 
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
@@ -616,6 +661,12 @@ packages:
 
   '@rushstack/eslint-patch@1.14.0':
     resolution: {integrity: sha512-WJFej426qe4RWOm9MMtP4V3CV4AucXolQty+GRgAWLgQXmpCuwzs7hEpxxhSc/znXUSxum9d/P/32MW0FlAAlA==}
+
+  '@standard-schema/spec@1.0.0-beta.4':
+    resolution: {integrity: sha512-d3IxtzLo7P1oZ8s8YNvxzBUXRXojSut8pbPrTYtzsc5sn4+53jVqbk66pQerSZbZSJZQux6LkclB/+8IDordHg==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -929,6 +980,22 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@uploadthing/mime-types@0.3.6':
+    resolution: {integrity: sha512-t3tTzgwFV9+1D7lNDYc7Lr7kBwotHaX0ZsvoCGe7xGnXKo9z0jG2Sjl/msll12FeoLj77nyhsxevXyGpQDBvLg==}
+
+  '@uploadthing/react@7.3.3':
+    resolution: {integrity: sha512-GhKbK42jL2Qs7OhRd2Z6j0zTLsnJTRJH31nR7RZnUYVoRh2aS/NabMAnHBNqfunIAGXVaA717Pvzq7vtxuPTmQ==}
+    peerDependencies:
+      next: '*'
+      react: ^17.0.2 || ^18.0.0 || ^19.0.0
+      uploadthing: ^7.2.0
+    peerDependenciesMeta:
+      next:
+        optional: true
+
+  '@uploadthing/shared@7.1.10':
+    resolution: {integrity: sha512-R/XSA3SfCVnLIzFpXyGaKPfbwlYlWYSTuGjTFHuJhdAomuBuhopAHLh2Ois5fJibAHzi02uP1QCKbgTAdmArqg==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1256,6 +1323,9 @@ packages:
   easymde@2.20.0:
     resolution: {integrity: sha512-V1Z5f92TfR42Na852OWnIZMbM7zotWQYTddNaLYZFVKj7APBbyZ3FYJ27gBw2grMW3R6Qdv9J8n5Ij7XRSIgXQ==}
 
+  effect@3.17.7:
+    resolution: {integrity: sha512-dpt0ONUn3zzAuul6k4nC/coTTw27AL5nhkORXgTi6NfMPzqWYa1M05oKmOMTxpVSTKepqXVcW9vIwkuaaqx9zA==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -1462,6 +1532,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1501,9 +1575,16 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-selector@0.6.0:
+    resolution: {integrity: sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==}
+    engines: {node: '>= 12'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  find-my-way-ts@0.1.6:
+    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -2227,6 +2308,16 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.8:
+    resolution: {integrity: sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA==}
+
+  multipasta@0.2.7:
+    resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
+
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
@@ -2282,6 +2373,10 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   oauth@0.9.15:
     resolution: {integrity: sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==}
@@ -2480,6 +2575,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
@@ -2686,6 +2784,9 @@ packages:
   sparse-bitfield@3.0.3:
     resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
 
+  sqids@0.3.0:
+    resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -2868,6 +2969,27 @@ packages:
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
+  uploadthing@7.7.4:
+    resolution: {integrity: sha512-rlK/4JWHW5jP30syzWGBFDDXv3WJDdT8gn9OoxRJmXLoXi94hBmyyjxihGlNrKhBc81czyv8TkzMioe/OuKGfA==}
+    engines: {node: '>=18.13.0'}
+    peerDependencies:
+      express: '*'
+      fastify: '*'
+      h3: '*'
+      next: '*'
+      tailwindcss: ^3.0.0 || ^4.0.0-beta.0
+    peerDependenciesMeta:
+      express:
+        optional: true
+      fastify:
+        optional: true
+      h3:
+        optional: true
+      next:
+        optional: true
+      tailwindcss:
+        optional: true
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -2967,6 +3089,14 @@ snapshots:
   '@babel/runtime@7.28.4': {}
 
   '@cfworker/json-schema@4.1.1': {}
+
+  '@effect/platform@0.90.3(effect@3.17.7)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.39.0
+      effect: 3.17.7
+      find-my-way-ts: 0.1.6
+      msgpackr: 1.11.8
+      multipasta: 0.2.7
 
   '@emnapi/core@1.6.0':
     dependencies:
@@ -3219,6 +3349,24 @@ snapshots:
     dependencies:
       sparse-bitfield: 3.0.3
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.6.0
@@ -3274,6 +3422,8 @@ snapshots:
       fastq: 1.19.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@opentelemetry/semantic-conventions@1.39.0': {}
 
   '@panva/hkdf@1.2.1': {}
 
@@ -3359,6 +3509,10 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.14.0': {}
+
+  '@standard-schema/spec@1.0.0-beta.4': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -3652,6 +3806,23 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@uploadthing/mime-types@0.3.6': {}
+
+  '@uploadthing/react@7.3.3(next@15.5.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(uploadthing@7.7.4(next@15.5.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tailwindcss@4.1.15))':
+    dependencies:
+      '@uploadthing/shared': 7.1.10
+      file-selector: 0.6.0
+      react: 19.1.0
+      uploadthing: 7.7.4(next@15.5.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tailwindcss@4.1.15)
+    optionalDependencies:
+      next: 15.5.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+
+  '@uploadthing/shared@7.1.10':
+    dependencies:
+      '@uploadthing/mime-types': 0.3.6
+      effect: 3.17.7
+      sqids: 0.3.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -3977,6 +4148,11 @@ snapshots:
       codemirror: 5.65.20
       codemirror-spell-checker: 1.1.2
       marked: 4.3.0
+
+  effect@3.17.7:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
 
   emoji-regex@10.6.0: {}
 
@@ -4313,6 +4489,10 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -4353,9 +4533,15 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-selector@0.6.0:
+    dependencies:
+      tslib: 2.8.1
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  find-my-way-ts@0.1.6: {}
 
   find-up@5.0.0:
     dependencies:
@@ -5312,6 +5498,24 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.8:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
+  multipasta@0.2.7: {}
+
   mustache@4.2.0: {}
 
   nano-spawn@2.0.0: {}
@@ -5359,6 +5563,11 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   oauth@0.9.15: {}
 
@@ -5558,6 +5767,8 @@ snapshots:
   property-information@7.1.0: {}
 
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   q@1.5.1: {}
 
@@ -5846,6 +6057,8 @@ snapshots:
     dependencies:
       memory-pager: 1.5.0
 
+  sqids@0.3.0: {}
+
   stable-hash@0.0.5: {}
 
   stop-iteration-iterator@1.1.0:
@@ -6092,6 +6305,17 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+
+  uploadthing@7.7.4(next@15.5.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tailwindcss@4.1.15):
+    dependencies:
+      '@effect/platform': 0.90.3(effect@3.17.7)
+      '@standard-schema/spec': 1.0.0-beta.4
+      '@uploadthing/mime-types': 0.3.6
+      '@uploadthing/shared': 7.1.10
+      effect: 3.17.7
+    optionalDependencies:
+      next: 15.5.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      tailwindcss: 4.1.15
 
   uri-js@4.4.1:
     dependencies:

--- a/src/app/(admin)/admin/layout.js
+++ b/src/app/(admin)/admin/layout.js
@@ -42,6 +42,7 @@ function AdminLayoutContent({ children }) {
     { name: 'Dashboard', href: '/admin/dashboard', icon: 'fas fa-tachometer-alt' },
     { name: 'Manage Sections', href: '/admin/sections', icon: 'fas fa-cog' },
     { name: 'Media Library', href: '/admin/media', icon: 'fas fa-images' },
+    { name: 'Storage', href: '/admin/storage', icon: 'fas fa-cloud' },
     { name: 'Messages', href: '/admin/contacts', icon: 'fas fa-envelope' },
     { name: 'Projects', href: '/admin/projects', icon: 'fas fa-folder' },
     { name: 'Services', href: '/admin/services', icon: 'fas fa-tools' },

--- a/src/app/(admin)/admin/storage/page.js
+++ b/src/app/(admin)/admin/storage/page.js
@@ -1,0 +1,27 @@
+'use client';
+
+// src/app/(admin)/admin/storage/page.js
+import { useState } from 'react';
+import AdminPageWrapper from '@/components/admin/AdminPageWrapper';
+import UploadThingManagerClient from '@/components/admin/UploadThingManagerClient';
+
+/**
+ * Admin storage management page powered by UploadThing.
+ *
+ * @returns {JSX.Element} The UploadThing storage manager page.
+ */
+export default function StoragePage() {
+  const [searchTerm, setSearchTerm] = useState('');
+
+  return (
+    <AdminPageWrapper
+      title="Storage Manager"
+      description="UploadThing-powered storage with uploads, usage insights, and file cleanup tools."
+      searchable={true}
+      searchPlaceholder="Search by file name, key, or status..."
+      onSearch={setSearchTerm}
+    >
+      <UploadThingManagerClient searchTerm={searchTerm} />
+    </AdminPageWrapper>
+  );
+}

--- a/src/app/api/uploadthing/core.js
+++ b/src/app/api/uploadthing/core.js
@@ -1,0 +1,34 @@
+// src/app/api/uploadthing/core.js
+import { getServerSession } from 'next-auth/next';
+import { createUploadthing } from 'uploadthing/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+
+const uploadBuilder = createUploadthing();
+
+/**
+ * UploadThing file router for admin-managed assets.
+ *
+ * @type {import('uploadthing/types').FileRouter}
+ */
+export const uploadRouter = {
+  mediaUploader: uploadBuilder({
+    image: { maxFileSize: '8MB', maxFileCount: 10 },
+    video: { maxFileSize: '128MB', maxFileCount: 2 },
+    pdf: { maxFileSize: '16MB', maxFileCount: 5 },
+  })
+    .middleware(async () => {
+      const session = await getServerSession(authOptions);
+
+      if (!session || session.user?.role !== 'admin') {
+        throw new Error('Unauthorized');
+      }
+
+      return { uploaderId: session.user?.id || session.user?.email || 'admin' };
+    })
+    .onUploadComplete(async ({ file, metadata }) => {
+      return {
+        uploaderId: metadata.uploaderId,
+        fileKey: file.key,
+      };
+    }),
+};

--- a/src/app/api/uploadthing/delete/route.js
+++ b/src/app/api/uploadthing/delete/route.js
@@ -1,0 +1,65 @@
+// src/app/api/uploadthing/delete/route.js
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { UTApi } from 'uploadthing/server';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+
+const utapi = new UTApi();
+
+/**
+ * Verifies that the current session belongs to an admin user.
+ *
+ * @async
+ * @function isAdmin
+ * @returns {Promise<boolean>} Whether the user is authenticated as an admin.
+ */
+async function isAdmin() {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session || !session.user) {
+      return false;
+    }
+
+    return session.user.role === 'admin';
+  } catch (error) {
+    console.error('UploadThing admin check failed:', error);
+    return false;
+  }
+}
+
+/**
+ * Deletes one or more files from UploadThing storage.
+ *
+ * @async
+ * @function POST
+ * @param {Request} request - Incoming request with file keys to delete.
+ * @returns {Promise<NextResponse>} JSON response with deletion status.
+ */
+export async function POST(request) {
+  try {
+    const isAuthorized = await isAdmin();
+
+    if (!isAuthorized) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const payload = await request.json();
+    const fileKeys = Array.isArray(payload?.fileKeys)
+      ? payload.fileKeys
+      : payload?.fileKey
+        ? [payload.fileKey]
+        : [];
+
+    if (!fileKeys.length) {
+      return NextResponse.json({ error: 'Missing file keys' }, { status: 400 });
+    }
+
+    const result = await utapi.deleteFiles(fileKeys);
+
+    return NextResponse.json({ success: result.success, deletedCount: result.deletedCount });
+  } catch (error) {
+    console.error('Failed to delete UploadThing files:', error);
+    return NextResponse.json({ error: 'Failed to delete files' }, { status: 500 });
+  }
+}

--- a/src/app/api/uploadthing/list/route.js
+++ b/src/app/api/uploadthing/list/route.js
@@ -1,0 +1,74 @@
+// src/app/api/uploadthing/list/route.js
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { UTApi } from 'uploadthing/server';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+
+const utapi = new UTApi();
+
+/**
+ * Verifies that the current session belongs to an admin user.
+ *
+ * @async
+ * @function isAdmin
+ * @returns {Promise<boolean>} Whether the user is authenticated as an admin.
+ */
+async function isAdmin() {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session || !session.user) {
+      return false;
+    }
+
+    return session.user.role === 'admin';
+  } catch (error) {
+    console.error('UploadThing admin check failed:', error);
+    return false;
+  }
+}
+
+/**
+ * Returns a paginated list of UploadThing files and usage details.
+ *
+ * @async
+ * @function GET
+ * @param {Request} request - Incoming request with pagination parameters.
+ * @returns {Promise<NextResponse>} JSON response containing files and usage data.
+ */
+export async function GET(request) {
+  try {
+    const isAuthorized = await isAdmin();
+
+    if (!isAuthorized) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(Number(searchParams.get('limit')) || 20, 100);
+    const offset = Math.max(Number(searchParams.get('offset')) || 0, 0);
+
+    const [listResult, usageResult] = await Promise.all([
+      utapi.listFiles({ limit, offset }),
+      utapi.getUsageInfo(),
+    ]);
+
+    const keys = listResult.files.map((file) => file.key);
+    const urlsResult = keys.length ? await utapi.getFileUrls(keys) : { data: [] };
+    const urlsByKey = new Map(urlsResult.data.map((file) => [file.key, file.url]));
+
+    const filesWithUrls = listResult.files.map((file) => ({
+      ...file,
+      url: urlsByKey.get(file.key) || null,
+    }));
+
+    return NextResponse.json({
+      files: filesWithUrls,
+      hasMore: listResult.hasMore,
+      usage: usageResult,
+    });
+  } catch (error) {
+    console.error('Failed to list UploadThing files:', error);
+    return NextResponse.json({ error: 'Failed to list files' }, { status: 500 });
+  }
+}

--- a/src/app/api/uploadthing/route.js
+++ b/src/app/api/uploadthing/route.js
@@ -1,0 +1,7 @@
+// src/app/api/uploadthing/route.js
+import { createRouteHandler } from 'uploadthing/next';
+import { uploadRouter } from '@/app/api/uploadthing/core';
+
+export const { GET, POST } = createRouteHandler({
+  router: uploadRouter,
+});

--- a/src/components/admin/UploadThingManagerClient.js
+++ b/src/components/admin/UploadThingManagerClient.js
@@ -1,0 +1,316 @@
+'use client';
+
+// src/components/admin/UploadThingManagerClient.js
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { UploadButton } from '@uploadthing/react';
+import { Button } from '@/components/ui';
+
+const PAGE_SIZE = 12;
+
+/**
+ * Format byte counts into human-readable strings.
+ *
+ * @param {number} bytes - The number of bytes to format.
+ * @returns {string} Formatted string (e.g., "4.2 MB").
+ */
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0 B';
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** exponent;
+
+  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+}
+
+/**
+ * UploadThing storage manager client for admin usage.
+ *
+ * @param {Object} props - Component props.
+ * @param {string} props.searchTerm - Search term for filtering files.
+ * @returns {JSX.Element} The UploadThing storage manager interface.
+ */
+export default function UploadThingManagerClient({ searchTerm }) {
+  const [files, setFiles] = useState([]);
+  const [usage, setUsage] = useState(null);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [actionMessage, setActionMessage] = useState('');
+
+  const fetchFiles = useCallback(async () => {
+    setIsLoading(true);
+    setErrorMessage('');
+
+    try {
+      const offset = (page - 1) * PAGE_SIZE;
+      const response = await fetch(`/api/uploadthing/list?limit=${PAGE_SIZE}&offset=${offset}`);
+
+      if (!response.ok) {
+        throw new Error('Failed to load UploadThing assets.');
+      }
+
+      const data = await response.json();
+      setFiles(data.files || []);
+      setHasMore(Boolean(data.hasMore));
+      setUsage(data.usage || null);
+    } catch (error) {
+      setErrorMessage(error.message || 'Unable to load storage data.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [page]);
+
+  useEffect(() => {
+    fetchFiles();
+  }, [fetchFiles]);
+
+  const filteredFiles = useMemo(() => {
+    if (!searchTerm) {
+      return files;
+    }
+
+    const normalized = searchTerm.toLowerCase();
+    return files.filter((file) => {
+      return (
+        file.name?.toLowerCase().includes(normalized) ||
+        file.key?.toLowerCase().includes(normalized) ||
+        file.status?.toLowerCase().includes(normalized)
+      );
+    });
+  }, [files, searchTerm]);
+
+  const handleDelete = async (fileKey) => {
+    setActionMessage('');
+
+    try {
+      const response = await fetch('/api/uploadthing/delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fileKey }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to delete file.');
+      }
+
+      setActionMessage('File deleted successfully.');
+      await fetchFiles();
+    } catch (error) {
+      setErrorMessage(error.message || 'Unable to delete file.');
+    }
+  };
+
+  const handleCopy = async (value, label) => {
+    setActionMessage('');
+
+    try {
+      await navigator.clipboard.writeText(value);
+      setActionMessage(`${label} copied to clipboard.`);
+    } catch (error) {
+      setErrorMessage('Failed to copy to clipboard.');
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <div className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm">
+          <p className="text-sm text-neutral-500">Total Usage</p>
+          <p className="text-2xl font-semibold text-neutral-900">
+            {usage ? formatBytes(usage.totalBytes) : '—'}
+          </p>
+        </div>
+        <div className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm">
+          <p className="text-sm text-neutral-500">App Usage</p>
+          <p className="text-2xl font-semibold text-neutral-900">
+            {usage ? formatBytes(usage.appTotalBytes) : '—'}
+          </p>
+        </div>
+        <div className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm">
+          <p className="text-sm text-neutral-500">Files Uploaded</p>
+          <p className="text-2xl font-semibold text-neutral-900">{usage?.filesUploaded ?? '—'}</p>
+        </div>
+        <div className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm">
+          <p className="text-sm text-neutral-500">Storage Limit</p>
+          <p className="text-2xl font-semibold text-neutral-900">
+            {usage ? formatBytes(usage.limitBytes) : '—'}
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-neutral-200 bg-white p-6 shadow-sm space-y-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-neutral-900">Upload new files</h2>
+            <p className="text-sm text-neutral-500">
+              Upload images, videos, or PDFs directly to UploadThing.
+            </p>
+          </div>
+          <UploadButton
+            endpoint="mediaUploader"
+            onClientUploadComplete={() => {
+              setActionMessage('Upload complete. Refreshing files...');
+              fetchFiles();
+            }}
+            onUploadError={(error) => {
+              setErrorMessage(error.message || 'Upload failed.');
+            }}
+            appearance={{
+              button:
+                'bg-neutral-900 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-neutral-800',
+              allowedContent: 'text-xs text-neutral-500',
+            }}
+          />
+        </div>
+        <div className="text-xs text-neutral-500">
+          Tip: search filters the files listed on the current page.
+        </div>
+      </div>
+
+      {errorMessage && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {errorMessage}
+        </div>
+      )}
+
+      {actionMessage && (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+          {actionMessage}
+        </div>
+      )}
+
+      <div className="rounded-xl border border-neutral-200 bg-white shadow-sm overflow-hidden">
+        <div className="border-b border-neutral-200 px-6 py-4 flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-neutral-900">Stored files</h3>
+            <p className="text-sm text-neutral-500">
+              {isLoading
+                ? 'Loading files...'
+                : `${filteredFiles.length} of ${files.length} file(s) shown`}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={() => fetchFiles()}
+              className="text-xs"
+            >
+              <i className="fas fa-sync-alt mr-2"></i>
+              Refresh
+            </Button>
+          </div>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead className="bg-neutral-50 text-left">
+              <tr>
+                <th className="px-6 py-3 font-medium text-neutral-600">File</th>
+                <th className="px-6 py-3 font-medium text-neutral-600">Status</th>
+                <th className="px-6 py-3 font-medium text-neutral-600">Size</th>
+                <th className="px-6 py-3 font-medium text-neutral-600">Uploaded</th>
+                <th className="px-6 py-3 font-medium text-neutral-600">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-neutral-100">
+              {isLoading && (
+                <tr>
+                  <td className="px-6 py-6 text-neutral-500" colSpan={5}>
+                    Loading files...
+                  </td>
+                </tr>
+              )}
+              {!isLoading && filteredFiles.length === 0 && (
+                <tr>
+                  <td className="px-6 py-6 text-neutral-500" colSpan={5}>
+                    No files found for this page.
+                  </td>
+                </tr>
+              )}
+              {!isLoading &&
+                filteredFiles.map((file) => (
+                  <tr key={file.key} className="hover:bg-neutral-50">
+                    <td className="px-6 py-4">
+                      <div className="font-medium text-neutral-900">{file.name}</div>
+                      <div className="text-xs text-neutral-500 break-all">{file.key}</div>
+                    </td>
+                    <td className="px-6 py-4">
+                      <span className="inline-flex items-center rounded-full bg-neutral-100 px-2.5 py-1 text-xs font-medium text-neutral-700">
+                        {file.status}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 text-neutral-600">{formatBytes(file.size)}</td>
+                    <td className="px-6 py-4 text-neutral-600">
+                      {new Date(file.uploadedAt).toLocaleString()}
+                    </td>
+                    <td className="px-6 py-4">
+                      <div className="flex flex-wrap gap-2">
+                        {file.url && (
+                          <Button
+                            variant="ghost"
+                            size="small"
+                            onClick={() => handleCopy(file.url, 'File URL')}
+                            className="text-xs"
+                          >
+                            <i className="fas fa-link mr-1"></i>
+                            Copy URL
+                          </Button>
+                        )}
+                        <Button
+                          variant="ghost"
+                          size="small"
+                          onClick={() => handleCopy(file.key, 'File key')}
+                          className="text-xs"
+                        >
+                          <i className="fas fa-key mr-1"></i>
+                          Copy key
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="small"
+                          onClick={() => handleDelete(file.key)}
+                          className="text-xs text-red-600"
+                        >
+                          <i className="fas fa-trash-alt mr-1"></i>
+                          Delete
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="flex flex-col items-center gap-3 border-t border-neutral-200 px-6 py-4 sm:flex-row sm:justify-between">
+          <span className="text-xs text-neutral-500">Page {page}</span>
+          <div className="flex gap-2">
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+              className="text-xs"
+              disabled={page === 1}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={() => setPage((prev) => prev + 1)}
+              className="text-xs"
+              disabled={!hasMore}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Integrate UploadThing to provide a dedicated admin storage manager for uploading and managing app assets.
- Expose admin-protected APIs to list, inspect, and delete files stored in UploadThing so storage can be managed from the admin panel.

### Description

- Added UploadThing client/server packages to `package.json` and updated lockfile (`uploadthing`, `@uploadthing/react`).
- Implemented UploadThing router and route handler in `src/app/api/uploadthing/*` (`core.js`, `route.js`) and admin-protected endpoints `list/route.js` and `delete/route.js` that use `UTApi` for listing, usage info, and deleting files.
- Created a React admin UI component `src/components/admin/UploadThingManagerClient.js` (upload button, usage cards, search, pagination, copy/delete actions) and a page `src/app/(admin)/admin/storage/page.js` that wraps it with `AdminPageWrapper`.
- Added a sidebar link to the admin navigation in `src/app/(admin)/admin/layout.js` and wired `UploadButton` uploads to refresh the listing after completion.

### Testing

- Installed packages with `pnpm add uploadthing @uploadthing/react`, which completed successfully and updated `package.json`/lockfile.
- Started the dev server with `pnpm run dev`; Next compiled and served the app and compiled the new `/admin/storage` page successfully (server ran).
- Captured a headless screenshot of `http://127.0.0.1:3000/admin/storage` using Playwright to verify rendering, but the request returned HTTP 500 due to a missing environment variable (`MONGODB_URI`), so full end-to-end API verification could not be completed.
- Prettier formatting ran as part of the commit hooks and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981b72448c48320861719bf5ef45eee)