### PR TITLE
fix: update langchain import and webpack fallbacks for node modules

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -60,6 +60,26 @@ const nextConfig = {
       bodySizeLimit: '10mb',
     },
   },
+  webpack: (config, { isServer, webpack }) => {
+    if (!isServer) {
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        fs: false,
+        https: false,
+        http: false,
+        net: false,
+        tls: false,
+        crypto: false,
+      };
+
+      config.plugins.push(
+        new webpack.NormalModuleReplacementPlugin(/^node:/, (resource) => {
+          resource.request = resource.request.replace(/^node:/, '');
+        })
+      );
+    }
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/tools/presentation/generate/route.js
+++ b/src/app/api/tools/presentation/generate/route.js
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
 import { ChatOpenAI } from '@langchain/openai';
 import { PromptTemplate } from '@langchain/core/prompts';
-import { StructuredOutputParser } from 'langchain/output_parsers';
+import { StructuredOutputParser } from '@langchain/core/output_parsers';
 import dbConnect from '@/lib/dbConnect';
 import ChatbotSettings from '@/models/ChatbotSettings';
 import { decrypt } from '@/lib/crypto';


### PR DESCRIPTION
The build was failing due to two issues:
1. `Module not found` for `langchain/output_parsers` in the API route. This has been updated to use the correct `@langchain/core/output_parsers` package which resolves the missing import.
2. Webpack errors during client component compilation due to Node.js core modules (`fs`, `https`, `node:fs`, `node:https`) imported by `pptxgenjs`. This has been fixed by configuring Webpack fallbacks and adding a `NormalModuleReplacementPlugin` to strip the `node:` prefix and resolve to the `false` fallbacks.

The build now successfully compiles these components. Note that running the build locally still fails at the page data collection stage due to missing MongoDB credentials, but the Webpack compilation phase succeeds, confirming the fixes work.

---
*PR created automatically by Jules for task [11052289216946017291](https://jules.google.com/task/11052289216946017291) started by @hasanraiyan*