### PR TITLE
Update presentation agent visual prompts and remove hex codes

### DIFF
--- a/src/lib/agents/ai/presentation-agent.js
+++ b/src/lib/agents/ai/presentation-agent.js
@@ -61,7 +61,7 @@ class PresentationAgent extends BaseAgent {
       this.logger.error('Failed getting MCP Tools for Presentation Agent:', e);
     }
 
-    const systemPrompt = `You are an elite Presentation Designer and Visual Director. Research the topic, then create a COMPLETE presentation with full visual slide design briefs.
+    const systemPrompt = `You are an elite Presentation Designer and Visual Director. Research the topic, then create a COMPLETE presentation by generating highly detailed visual prompts for each slide.
 
 Respond ONLY with raw JSON. No markdown wrapping.
 
@@ -69,30 +69,24 @@ Topic: ${topic}
 Additional Instructions: ${extraInstructions}
 
 ━━━ DESIGN GUARDRAILS ━━━
-1. LIGHT MODE DEFAULT: Unless Additional Instructions explicitly request dark/colored themes, use: pure white (#FFFFFF) background, dark charcoal (#1A1A2E) headings, medium gray (#4A4A5A) body text, deep blue (#2563EB) as primary accent, indigo (#4F46E5) secondary, sky blue (#38BDF8) tertiary.
+1. USE NATURAL LANGUAGE COLORS: Do NOT use any hex codes (e.g., avoid #FFFFFF). Instead, use natural language color descriptions like "pure white", "dark charcoal", "medium gray", "deep blue", "indigo", and "sky blue". Unless instructed otherwise, default to a light mode palette with these natural language colors.
 2. DIAGRAMS ARE MANDATORY: Every content slide MUST feature a rich visual — process flowcharts, isometric 3D infographics, comparison tables, radial diagrams, timelines, data charts, layered architecture diagrams, or icon grids. Plain text-only slides are FORBIDDEN.
 3. STRICT CONSISTENCY: Same background, same fonts, same color palette on EVERY slide. Only content and layout composition change. Think Google Slides master template.
-4. LAYOUT VARIETY: Mix different compositions across slides — 60/40 splits, centered hero visuals, full-width infographics, multi-column grids, timeline strips — but ALWAYS within the same design system.
+4. TEXT EMBEDDED IN VISUAL: The image generator can draw text, so you MUST include the exact text you want to appear on the slide (title, bullet points, labels) directly inside your visual prompt. Describe exactly where and how this text should be written.
 
 ━━━ JSON FORMAT ━━━
 {
-  "presentationTheme": "The master design system string. Must specify: background color, font family & weights, primary/secondary/accent hex colors, and visual style. If user didn't request a specific style, default to the light mode palette from Guardrail #1.",
   "slides": [
     {
-      "title": "Slide Title",
-      "points": ["Key point 1", "Key point 2"],
-      "slideDesignBrief": "Complete art direction for this slide as a 16:9 image. Structure: BACKGROUND (restate from theme), TITLE (position, weight, color, size), BODY (text layout), HERO VISUAL (the diagram/infographic/3D scene — describe in EXTREME detail: every shape, color, label, arrow, icon, proportion, and spatial position), ACCENTS (decorative elements), COMPOSITION (spatial layout type). Must be so detailed the image AI can render it pixel-perfect without guessing."
+      "visualPrompt": "A single, highly detailed paragraph describing the complete visual layout, colors (in natural language only), diagrams, 3D elements, and the EXACT TEXT (title, points, annotations) to be drawn on this 16:9 slide."
     }
   ]
 }
 
 ━━━ HERO VISUAL EXAMPLES (for inspiration — don't copy, adapt to the topic) ━━━
-- Title Slide: Large 3D glossy emblem of the topic floating center, with the title in bold above and a subtle tagline below. Clean, dramatic, minimal.
-- Process Slide: A 5-step horizontal pipeline diagram with numbered circular nodes connected by gradient arrows, each node containing an icon and label.
-- Architecture Slide: Layered isometric 3D blocks showing system components stacked and connected with data flow lines.
-- Comparison Slide: Side-by-side columns with icon headers, checkmarks/crosses, and a gradient divider line.
-- Data Slide: Large donut chart or bar chart with annotated callouts, percentage labels, and a legend strip.
-- Timeline Slide: Horizontal or vertical timeline with milestone markers, year labels, and small icon illustrations at each node.
+- Title Slide: Large 3D glossy emblem of the topic floating center, with the exact title text written in bold above and a subtle tagline below. Clean, dramatic, minimal.
+- Process Slide: A 5-step horizontal pipeline diagram with numbered circular nodes connected by gradient arrows, each node containing an icon and a specific text label.
+- Architecture Slide: Layered isometric 3D blocks showing system components stacked and connected with data flow lines and exact text annotations.
 
 Generate 6-8 slides with a clear arc: Title → Context → Deep Dives (with diagrams) → Key Insights → Conclusion/CTA.`;
 
@@ -131,24 +125,17 @@ Generate 6-8 slides with a clear arc: Title → Context → Deep Dives (with dia
   /**
    * Generates a single visual slide using the central Image Generator Agent.
    */
-  async generateSlideImage(slide, presentationTheme) {
+  async generateSlideImage(slide) {
     if (!this.isInitialized) await this.initialize();
 
     const fullPrompt = `Generate a single, production-ready presentation slide as a flat 16:9 image.
 
-DESIGN SYSTEM (enforce exactly):
-${presentationTheme}
+SLIDE VISUAL PROMPT:
+${slide.visualPrompt}
 
-SLIDE BRIEF:
-${slide.slideDesignBrief}
+Rules: razor-sharp legible text, rich detailed visuals, consistent with the design system described. No borders, no UI chrome, no slide frames. Single flat image only.`;
 
-TEXT CONTENT:
-Title: ${slide.title}
-${slide.points.map((p) => '• ' + p).join('\n')}
-
-Rules: razor-sharp legible text, rich detailed visuals, consistent with the design system. No borders, no UI chrome, no slide frames. Single flat image only.`;
-
-    this.logger.info(`Generating slide using IMAGE_GENERATOR: ${slide.title}`);
+    this.logger.info(`Generating slide using IMAGE_GENERATOR from visual prompt...`);
 
     try {
       const imageAgent = agentRegistry.get(AGENT_IDS.IMAGE_GENERATOR);
@@ -162,11 +149,11 @@ Rules: razor-sharp legible text, rich detailed visuals, consistent with the desi
       return {
         imageUrl: base64Data,
         prompt: fullPrompt,
-        fallbackText: `Slide: ${slide.title}. ${slide.points.join('. ')}`,
-        slideDesignBrief: slide.slideDesignBrief,
+        fallbackText: `Visual Prompt: ${slide.visualPrompt.substring(0, 50)}...`,
+        visualPrompt: slide.visualPrompt,
       };
     } catch (error) {
-      this.logger.error(`Failed to generate image for slide: ${slide.title}`, error);
+      this.logger.error(`Failed to generate image for slide`, error);
       throw error;
     }
   }
@@ -177,11 +164,11 @@ Rules: razor-sharp legible text, rich detailed visuals, consistent with the desi
   async generatePresentationVisuals(outlineData) {
     if (!this.isInitialized) await this.initialize();
 
-    const { presentationTheme, slides } = outlineData;
+    const { slides } = outlineData;
 
-    this.logger.info(`Starting parallel generation of ${slides.length} slides with dynamic theme.`);
+    this.logger.info(`Starting parallel generation of ${slides.length} slides.`);
 
-    const slidePromises = slides.map((slide) => this.generateSlideImage(slide, presentationTheme));
+    const slidePromises = slides.map((slide) => this.generateSlideImage(slide));
 
     const results = await Promise.allSettled(slidePromises);
 
@@ -193,8 +180,8 @@ Rules: razor-sharp legible text, rich detailed visuals, consistent with the desi
         this.logger.error(`Slide ${index} failed:`, result.reason);
         finalSlides.push({
           imageUrl: null,
-          prompt: slides[index].slideDesignBrief,
-          fallbackText: `[FAILED TO GENERATE] Slide: ${slides[index].title}`,
+          prompt: slides[index].visualPrompt,
+          fallbackText: `[FAILED TO GENERATE] Slide prompt: ${slides[index].visualPrompt.substring(0, 50)}...`,
           error: result.reason.message,
         });
       }


### PR DESCRIPTION
This PR addresses the request to upgrade the presentation agent to stop generating structured outlines and hex codes. Instead, it now requests natural language color descriptions (e.g., "pure white") and generates a single descriptive paragraph (`visualPrompt`) for each slide. The internal methods that assemble prompts for the image generator have been refactored to read from this new structure.

---
*PR created automatically by Jules for task [8725478881749187595](https://jules.google.com/task/8725478881749187595) started by @hasanraiyan*