### PR TITLE
feat: redesign admin auth to use MongoDB-backed single admin account

### DIFF
--- a/src/app/(public)/admin/setup/AdminSetupClient.js
+++ b/src/app/(public)/admin/setup/AdminSetupClient.js
@@ -1,0 +1,197 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui';
+
+export default function AdminSetupClient() {
+  const router = useRouter();
+  const [formData, setFormData] = useState({
+    token: '',
+    name: '',
+    email: '',
+    password: '',
+    confirmPassword: ''
+  });
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+
+    if (formData.password !== formData.confirmPassword) {
+      setError('Passwords do not match.');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const response = await fetch('/api/admin/setup', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          token: formData.token,
+          name: formData.name,
+          email: formData.email,
+          password: formData.password,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Setup failed');
+      }
+
+      setSuccess(true);
+      setTimeout(() => {
+        router.push('/admin/login');
+      }, 3000);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-md w-full text-center">
+          <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-green-100 mb-4">
+            <svg className="h-6 w-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+          <h2 className="text-3xl font-extrabold text-gray-900 mb-2">Setup Complete</h2>
+          <p className="text-gray-600">Admin user created successfully. Redirecting to login...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            Admin Setup
+          </h2>
+          <p className="mt-2 text-center text-sm text-gray-600">
+            Create the primary administrator account
+          </p>
+        </div>
+
+        {error && (
+          <div className="rounded-md bg-red-50 p-4 border-l-4 border-red-500">
+            <div className="flex">
+              <div className="ml-3">
+                <h3 className="text-sm font-medium text-red-800">{error}</h3>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+          <div className="rounded-md shadow-sm space-y-4">
+            <div>
+              <label className="block text-sm font-semibold text-black mb-2 uppercase tracking-wider">
+                Setup Token
+              </label>
+              <input
+                name="token"
+                type="text"
+                required
+                className="w-full px-4 py-3 border-2 border-neutral-200 rounded-lg focus:outline-none focus:border-black transition-colors"
+                placeholder="From ADMIN_SETUP_TOKEN env var"
+                value={formData.token}
+                onChange={handleChange}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-semibold text-black mb-2 uppercase tracking-wider">
+                Full Name
+              </label>
+              <input
+                name="name"
+                type="text"
+                required
+                className="w-full px-4 py-3 border-2 border-neutral-200 rounded-lg focus:outline-none focus:border-black transition-colors"
+                placeholder="Admin Name"
+                value={formData.name}
+                onChange={handleChange}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-semibold text-black mb-2 uppercase tracking-wider">
+                Email Address
+              </label>
+              <input
+                name="email"
+                type="email"
+                required
+                className="w-full px-4 py-3 border-2 border-neutral-200 rounded-lg focus:outline-none focus:border-black transition-colors"
+                placeholder="admin@example.com"
+                value={formData.email}
+                onChange={handleChange}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-semibold text-black mb-2 uppercase tracking-wider">
+                Password
+              </label>
+              <input
+                name="password"
+                type="password"
+                required
+                className="w-full px-4 py-3 border-2 border-neutral-200 rounded-lg focus:outline-none focus:border-black transition-colors"
+                placeholder="Strong Password"
+                value={formData.password}
+                onChange={handleChange}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-semibold text-black mb-2 uppercase tracking-wider">
+                Confirm Password
+              </label>
+              <input
+                name="confirmPassword"
+                type="password"
+                required
+                className="w-full px-4 py-3 border-2 border-neutral-200 rounded-lg focus:outline-none focus:border-black transition-colors"
+                placeholder="Confirm Password"
+                value={formData.confirmPassword}
+                onChange={handleChange}
+              />
+            </div>
+          </div>
+
+          <div>
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={isLoading}
+              className="w-full py-3 px-4"
+            >
+              {isLoading ? 'Setting up...' : 'Complete Setup'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(public)/admin/setup/page.js
+++ b/src/app/(public)/admin/setup/page.js
@@ -1,0 +1,17 @@
+import AdminSetupClient from './AdminSetupClient';
+import { hasAdminUser } from '@/lib/auth/admin';
+import { redirect } from 'next/navigation';
+
+export const metadata = {
+  title: 'Admin Setup | Hasan Raiyan',
+  description: 'Initial setup for the platform administrator.',
+};
+
+export default async function AdminSetupPage() {
+  const adminExists = await hasAdminUser();
+  if (adminExists) {
+    redirect('/admin/login');
+  }
+
+  return <AdminSetupClient />;
+}


### PR DESCRIPTION
This PR addresses the "Public-Safe Admin Authentication Redesign" requirements by migrating the hardcoded, environment-variable-based admin authentication to a secure, MongoDB-backed authentication system using the existing `User` model. 

It introduces a one-time setup page (`/admin/setup`) protected by a rate-limited and timing-safe `ADMIN_SETUP_TOKEN` comparison to create the first admin user. Once created, this setup route is locked down forever. The `/admin/login` UI was also updated to accept an `email` and `password`.

Furthermore, all sensitive mutating server actions and miscellaneous admin API endpoints have been rigorously secured by introducing a central `requireAdminSession()` helper function that strictly checks for an active 'admin' role in the database. 

Old hardcoded authentication tokens (`id: '1'`) are actively rejected during the NextAuth callback phase to enforce a complete hard cutover.

---
*PR created automatically by Jules for task [7771885850880874446](https://jules.google.com/task/7771885850880874446) started by @hasanraiyan*