### PR TITLE
Refactor Admin Short Links Pages for Mobile Responsiveness

### DIFF
--- a/src/app/(admin)/admin/short-links/[slug]/page.js
+++ b/src/app/(admin)/admin/short-links/[slug]/page.js
@@ -208,67 +208,67 @@ export default function ShortLinkAnalyticsPage() {
       }
       description={linkDetails?.title || `Detailed click analytics for ${linkDetails?.destination}`}
       actionButton={
-        <div className="flex space-x-4 items-center">
+        <div className="flex flex-wrap gap-2 items-center w-full md:w-auto mt-4 md:mt-0 justify-end">
           <select
             value={days}
             onChange={(e) => setDays(e.target.value)}
-            className="border-2 border-neutral-300 rounded-md px-3 py-2 text-sm focus:border-black focus:ring-0 bg-white"
+            className="border-2 border-neutral-300 rounded-md px-3 py-2 text-sm focus:border-black focus:ring-0 bg-white w-full md:w-auto"
           >
             <option value="7">Last 7 Days</option>
             <option value="30">Last 30 Days</option>
             <option value="90">Last 90 Days</option>
           </select>
-          <Link href="/admin/short-links">
-            <Button variant="outline">
+          <Link href="/admin/short-links" className="w-full md:w-auto">
+            <Button variant="outline" className="w-full justify-center md:w-auto">
               <i className="fas fa-arrow-left mr-2"></i> Back
             </Button>
           </Link>
         </div>
       }
     >
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-        <Card variant="bordered" className="p-6">
-          <h3 className="text-sm font-medium text-neutral-500 uppercase tracking-wider">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 mb-8">
+        <Card variant="bordered" className="p-4 md:p-6">
+          <h3 className="text-xs md:text-sm font-medium text-neutral-500 uppercase tracking-wider">
             Total Clicks
           </h3>
-          <p className="text-3xl font-bold mt-2 font-['Playfair_Display']">{summary.totalClicks}</p>
+          <p className="text-2xl md:text-3xl font-bold mt-2 font-['Playfair_Display']">{summary.totalClicks}</p>
         </Card>
-        <Card variant="bordered" className="p-6">
-          <h3 className="text-sm font-medium text-neutral-500 uppercase tracking-wider">
+        <Card variant="bordered" className="p-4 md:p-6">
+          <h3 className="text-xs md:text-sm font-medium text-neutral-500 uppercase tracking-wider">
             Unique Visitors
           </h3>
-          <p className="text-3xl font-bold mt-2 font-['Playfair_Display']">
+          <p className="text-2xl md:text-3xl font-bold mt-2 font-['Playfair_Display']">
             {summary.uniqueVisitors}
           </p>
         </Card>
-        <Card variant="bordered" className="p-6">
-          <h3 className="text-sm font-medium text-neutral-500 uppercase tracking-wider">Status</h3>
+        <Card variant="bordered" className="p-4 md:p-6">
+          <h3 className="text-xs md:text-sm font-medium text-neutral-500 uppercase tracking-wider">Status</h3>
           <div className="mt-2">
             <Badge
               variant="tag"
               className={
-                linkDetails?.isActive ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+                linkDetails?.isActive ? 'bg-green-100 text-green-800 text-xs md:text-sm' : 'bg-red-100 text-red-800 text-xs md:text-sm'
               }
             >
               {linkDetails?.isActive ? 'Active' : 'Inactive'}
             </Badge>
           </div>
         </Card>
-        <Card variant="bordered" className="p-6">
-          <h3 className="text-sm font-medium text-neutral-500 uppercase tracking-wider">Tags</h3>
-          <div className="mt-2 flex flex-wrap gap-2">
+        <Card variant="bordered" className="p-4 md:p-6">
+          <h3 className="text-xs md:text-sm font-medium text-neutral-500 uppercase tracking-wider">Tags</h3>
+          <div className="mt-2 flex flex-wrap gap-1 md:gap-2">
             {linkDetails?.tags?.length > 0 ? (
               linkDetails.tags.map((tag) => (
                 <Badge
                   key={tag}
                   variant="tag"
-                  className="bg-neutral-100 text-neutral-800 border-neutral-200"
+                  className="bg-neutral-100 text-neutral-800 border-neutral-200 text-xs md:text-sm"
                 >
                   {tag}
                 </Badge>
               ))
             ) : (
-              <span className="text-sm text-neutral-400">No tags</span>
+              <span className="text-xs md:text-sm text-neutral-400">No tags</span>
             )}
           </div>
         </Card>
@@ -277,54 +277,54 @@ export default function ShortLinkAnalyticsPage() {
       {/* Click trends chart */}
       <Card
         variant="bordered"
-        className="p-6 mb-8 border-2 border-transparent hover:border-black transition-all"
+        className="p-4 md:p-6 mb-8 border-2 border-transparent hover:border-black transition-all overflow-hidden"
       >
-        <h3 className="text-lg font-bold mb-4 font-['Playfair_Display']">Clicks Over Time</h3>
+        <h3 className="text-base md:text-lg font-bold mb-4 font-['Playfair_Display']">Clicks Over Time</h3>
         {clicksOverTime.length > 0 ? (
-          <div className="h-72">
+          <div className="h-64 md:h-72 w-full">
             <Line data={chartData} options={chartOptions} />
           </div>
         ) : (
-          <div className="h-64 flex flex-col justify-center text-center text-neutral-400 bg-neutral-50 rounded-lg">
-            <i className="fas fa-chart-line text-4xl mb-2"></i>
-            <p>No analytics data available for the selected time range.</p>
+          <div className="h-56 md:h-64 flex flex-col justify-center text-center text-neutral-400 bg-neutral-50 rounded-lg p-4">
+            <i className="fas fa-chart-line text-3xl md:text-4xl mb-2"></i>
+            <p className="text-sm md:text-base">No analytics data available for the selected time range.</p>
           </div>
         )}
       </Card>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-        <Card variant="bordered" className="p-6">
-          <h3 className="text-lg font-bold mb-4 font-['Playfair_Display']">Top Referrers</h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 mb-8">
+        <Card variant="bordered" className="p-4 md:p-6">
+          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">Top Referrers</h3>
           {topReferrers.length > 0 ? (
-            <ul className="space-y-3">
+            <ul className="space-y-2 md:space-y-3">
               {topReferrers.map((ref, idx) => (
                 <li
                   key={idx}
-                  className="flex justify-between items-center text-sm border-b border-neutral-100 pb-2 last:border-0"
+                  className="flex justify-between items-center text-xs md:text-sm border-b border-neutral-100 pb-2 last:border-0"
                 >
-                  <span className="font-medium truncate max-w-[150px]">{ref.referrer}</span>
-                  <span className="text-neutral-500">{ref.count} clicks</span>
+                  <span className="font-medium truncate max-w-[120px] md:max-w-[150px]">{ref.referrer}</span>
+                  <span className="text-neutral-500 whitespace-nowrap">{ref.count} clicks</span>
                 </li>
               ))}
             </ul>
           ) : (
-            <p className="text-neutral-500 text-sm">No referrer data.</p>
+            <p className="text-neutral-500 text-xs md:text-sm">No referrer data.</p>
           )}
         </Card>
 
-        <Card variant="bordered" className="p-6">
-          <h3 className="text-lg font-bold mb-4 font-['Playfair_Display']">Custom Sources</h3>
+        <Card variant="bordered" className="p-4 md:p-6">
+          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">Custom Sources</h3>
           {topSources && topSources.length > 0 ? (
-            <ul className="space-y-3">
+            <ul className="space-y-2 md:space-y-3">
               {topSources.map((src, idx) => (
                 <li
                   key={idx}
-                  className="flex justify-between items-center text-sm border-b border-neutral-100 pb-2 last:border-0"
+                  className="flex justify-between items-center text-xs md:text-sm border-b border-neutral-100 pb-2 last:border-0"
                 >
-                  <span className="font-medium truncate max-w-[150px] capitalize">
+                  <span className="font-medium truncate max-w-[120px] md:max-w-[150px] capitalize">
                     {src.source}
                   </span>
-                  <span className="text-neutral-500">{src.count} clicks</span>
+                  <span className="text-neutral-500 whitespace-nowrap">{src.count} clicks</span>
                 </li>
               ))}
             </ul>
@@ -336,19 +336,19 @@ export default function ShortLinkAnalyticsPage() {
           )}
         </Card>
 
-        <Card variant="bordered" className="p-6">
-          <h3 className="text-lg font-bold mb-4 font-['Playfair_Display']">UTM Campaigns</h3>
+        <Card variant="bordered" className="p-4 md:p-6">
+          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">UTM Campaigns</h3>
           {topCampaigns && topCampaigns.length > 0 ? (
-            <ul className="space-y-3">
+            <ul className="space-y-2 md:space-y-3">
               {topCampaigns.map((camp, idx) => (
                 <li
                   key={idx}
-                  className="flex justify-between items-center text-sm border-b border-neutral-100 pb-2 last:border-0"
+                  className="flex justify-between items-center text-xs md:text-sm border-b border-neutral-100 pb-2 last:border-0"
                 >
-                  <span className="font-medium truncate max-w-[150px] capitalize">
+                  <span className="font-medium truncate max-w-[120px] md:max-w-[150px] capitalize">
                     {camp.campaign}
                   </span>
-                  <span className="text-neutral-500">{camp.count} clicks</span>
+                  <span className="text-neutral-500 whitespace-nowrap">{camp.count} clicks</span>
                 </li>
               ))}
             </ul>
@@ -360,48 +360,48 @@ export default function ShortLinkAnalyticsPage() {
           )}
         </Card>
 
-        <Card variant="bordered" className="p-6">
-          <h3 className="text-lg font-bold mb-4 font-['Playfair_Display']">Top Locations</h3>
+        <Card variant="bordered" className="p-4 md:p-6">
+          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">Top Locations</h3>
           {countries.length > 0 ? (
-            <ul className="space-y-3">
+            <ul className="space-y-2 md:space-y-3">
               {countries.map((loc, idx) => (
                 <li
                   key={idx}
-                  className="flex justify-between items-center text-sm border-b border-neutral-100 pb-2 last:border-0"
+                  className="flex justify-between items-center text-xs md:text-sm border-b border-neutral-100 pb-2 last:border-0"
                 >
-                  <span className="font-medium">{loc.country || 'Unknown'}</span>
-                  <span className="text-neutral-500">{loc.count} clicks</span>
+                  <span className="font-medium truncate max-w-[120px] md:max-w-[150px]">{loc.country || 'Unknown'}</span>
+                  <span className="text-neutral-500 whitespace-nowrap">{loc.count} clicks</span>
                 </li>
               ))}
             </ul>
           ) : (
-            <p className="text-neutral-500 text-sm">No location data.</p>
+            <p className="text-neutral-500 text-xs md:text-sm">No location data.</p>
           )}
         </Card>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 pb-12">
-        <Card variant="bordered" className="p-6">
-          <h3 className="text-lg font-bold mb-4 font-['Playfair_Display']">Devices</h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 pb-12">
+        <Card variant="bordered" className="p-4 md:p-6">
+          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">Devices</h3>
           {devices.length > 0 ? (
-            <ul className="space-y-3">
+            <ul className="space-y-2 md:space-y-3">
               {devices.map((dev, idx) => (
                 <li
                   key={idx}
-                  className="flex justify-between items-center text-sm border-b border-neutral-100 pb-2 last:border-0"
+                  className="flex justify-between items-center text-xs md:text-sm border-b border-neutral-100 pb-2 last:border-0"
                 >
-                  <span className="font-medium flex items-center gap-2">
+                  <span className="font-medium flex items-center gap-2 truncate max-w-[150px]">
                     <i
                       className={`fas fa-${dev.device === 'Mobile' ? 'mobile-alt' : dev.device === 'Tablet' ? 'tablet-alt' : 'desktop'}`}
                     ></i>
                     {dev.device || 'Unknown'}
                   </span>
-                  <span className="text-neutral-500">{dev.count} clicks</span>
+                  <span className="text-neutral-500 whitespace-nowrap">{dev.count} clicks</span>
                 </li>
               ))}
             </ul>
           ) : (
-            <p className="text-neutral-500 text-sm">No device data.</p>
+            <p className="text-neutral-500 text-xs md:text-sm">No device data.</p>
           )}
         </Card>
       </div>

--- a/src/app/(admin)/admin/short-links/page.js
+++ b/src/app/(admin)/admin/short-links/page.js
@@ -138,44 +138,71 @@ export default function ShortLinksDashboard() {
     >
       <Card variant="bordered" className="p-6">
         {loading ? (
-          <div className="overflow-x-auto">
-            <table className="w-full text-left border-collapse">
-              <thead>
-                <tr className="border-b-2 border-neutral-100">
-                  <th className="py-4 px-4 font-semibold text-sm">Status</th>
-                  <th className="py-4 px-4 font-semibold text-sm">Link</th>
-                  <th className="py-4 px-4 font-semibold text-sm">Destination</th>
-                  <th className="py-4 px-4 font-semibold text-sm">Clicks</th>
-                  <th className="py-4 px-4 font-semibold text-sm text-right">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {[...Array(5)].map((_, i) => (
-                  <tr key={i} className="border-b border-neutral-50">
-                    <td className="py-4 px-4">
-                      <Skeleton className="h-6 w-16" />
-                    </td>
-                    <td className="py-4 px-4">
+          <div className="w-full">
+            {/* Desktop Skeleton */}
+            <div className="hidden md:block overflow-x-auto">
+              <table className="w-full text-left border-collapse">
+                <thead>
+                  <tr className="border-b-2 border-neutral-100">
+                    <th className="py-4 px-4 font-semibold text-sm">Status</th>
+                    <th className="py-4 px-4 font-semibold text-sm">Link</th>
+                    <th className="py-4 px-4 font-semibold text-sm">Destination</th>
+                    <th className="py-4 px-4 font-semibold text-sm">Clicks</th>
+                    <th className="py-4 px-4 font-semibold text-sm text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[...Array(5)].map((_, i) => (
+                    <tr key={i} className="border-b border-neutral-50">
+                      <td className="py-4 px-4">
+                        <Skeleton className="h-6 w-16" />
+                      </td>
+                      <td className="py-4 px-4">
+                        <Skeleton className="h-5 w-32 mb-2" />
+                        <Skeleton className="h-3 w-20" />
+                      </td>
+                      <td className="py-4 px-4">
+                        <Skeleton className="h-4 w-48" />
+                      </td>
+                      <td className="py-4 px-4">
+                        <Skeleton className="h-5 w-8" />
+                      </td>
+                      <td className="py-4 px-4 text-right">
+                        <div className="flex justify-end space-x-2">
+                          <Skeleton className="h-8 w-8" />
+                          <Skeleton className="h-8 w-8" />
+                          <Skeleton className="h-8 w-8" />
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Mobile Skeleton */}
+            <div className="md:hidden space-y-4">
+              {[...Array(5)].map((_, i) => (
+                <div key={i} className="border border-neutral-100 rounded-lg p-4 space-y-3">
+                  <div className="flex justify-between items-start">
+                    <div>
                       <Skeleton className="h-5 w-32 mb-2" />
                       <Skeleton className="h-3 w-20" />
-                    </td>
-                    <td className="py-4 px-4">
-                      <Skeleton className="h-4 w-48" />
-                    </td>
-                    <td className="py-4 px-4">
-                      <Skeleton className="h-5 w-8" />
-                    </td>
-                    <td className="py-4 px-4 text-right">
-                      <div className="flex justify-end space-x-2">
-                        <Skeleton className="h-8 w-8" />
-                        <Skeleton className="h-8 w-8" />
-                        <Skeleton className="h-8 w-8" />
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+                    </div>
+                    <Skeleton className="h-6 w-16" />
+                  </div>
+                  <Skeleton className="h-4 w-full max-w-[200px]" />
+                  <div className="flex justify-between items-center pt-2">
+                    <Skeleton className="h-5 w-12" />
+                    <div className="flex space-x-2">
+                      <Skeleton className="h-8 w-8" />
+                      <Skeleton className="h-8 w-8" />
+                      <Skeleton className="h-8 w-8" />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
         ) : error ? (
           <div className="text-red-500 text-center py-8">{error}</div>
@@ -184,35 +211,98 @@ export default function ShortLinksDashboard() {
             <p>No SnapLinks found. Create your first link to get started.</p>
           </div>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-left border-collapse">
-              <thead>
-                <tr className="border-b-2 border-neutral-100">
-                  <th className="py-4 px-4 font-semibold text-sm">Status</th>
-                  <th className="py-4 px-4 font-semibold text-sm">Link</th>
-                  <th className="py-4 px-4 font-semibold text-sm">Destination</th>
-                  <th className="py-4 px-4 font-semibold text-sm">Clicks</th>
-                  <th className="py-4 px-4 font-semibold text-sm text-right">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {links.map((link) => (
-                  <tr key={link._id} className="border-b border-neutral-50 hover:bg-neutral-50">
-                    <td className="py-4 px-4">
-                      <Badge
-                        variant="tag"
-                        className={
-                          link.isActive ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
-                        }
-                      >
-                        {link.isActive ? 'Active' : 'Inactive'}
-                      </Badge>
-                    </td>
-                    <td className="py-4 px-4 max-w-[150px]">
-                      <div
-                        className="font-medium text-black truncate"
-                        title={link.title || link.slug}
-                      >
+          <div className="w-full">
+            {/* Desktop Table */}
+            <div className="hidden md:block overflow-x-auto">
+              <table className="w-full text-left border-collapse">
+                <thead>
+                  <tr className="border-b-2 border-neutral-100">
+                    <th className="py-4 px-4 font-semibold text-sm">Status</th>
+                    <th className="py-4 px-4 font-semibold text-sm">Link</th>
+                    <th className="py-4 px-4 font-semibold text-sm">Destination</th>
+                    <th className="py-4 px-4 font-semibold text-sm">Clicks</th>
+                    <th className="py-4 px-4 font-semibold text-sm text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {links.map((link) => (
+                    <tr key={link._id} className="border-b border-neutral-50 hover:bg-neutral-50">
+                      <td className="py-4 px-4">
+                        <Badge
+                          variant="tag"
+                          className={
+                            link.isActive ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+                          }
+                        >
+                          {link.isActive ? 'Active' : 'Inactive'}
+                        </Badge>
+                      </td>
+                      <td className="py-4 px-4 max-w-[150px]">
+                        <div
+                          className="font-medium text-black truncate"
+                          title={link.title || link.slug}
+                        >
+                          {link.title || link.slug}
+                        </div>
+                        <div className="text-xs text-neutral-500 flex items-center mt-1 break-all">
+                          /r/{link.slug}
+                          <button
+                            onClick={() => handleCopyLink(link.slug)}
+                            className="ml-2 text-neutral-400 hover:text-black transition"
+                            title="Copy Link"
+                          >
+                            <i className="fas fa-copy"></i>
+                          </button>
+                        </div>
+                      </td>
+                      <td className="py-4 px-4 max-w-xs truncate text-sm text-neutral-600">
+                        <a
+                          href={link.destination}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="hover:underline"
+                        >
+                          {link.destination}
+                        </a>
+                      </td>
+                      <td className="py-4 px-4 text-sm font-medium">{link.totalClicks}</td>
+                      <td className="py-4 px-4 text-right space-x-2">
+                        <Link href={`/admin/short-links/${link.slug}`}>
+                          <Button variant="outline" size="sm" className="px-2 py-1 h-8">
+                            <i className="fas fa-chart-bar"></i>
+                          </Button>
+                        </Link>
+                        {/* Space reserved for future QR Code feature */}
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="px-2 py-1 h-8"
+                          onClick={() => openEditModal(link)}
+                        >
+                          <i className="fas fa-edit"></i>
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="px-2 py-1 h-8 text-red-600 border-red-200 hover:bg-red-50"
+                          onClick={() => handleDelete(link._id)}
+                        >
+                          <i className="fas fa-trash"></i>
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Mobile Cards */}
+            <div className="md:hidden space-y-4">
+              {links.map((link) => (
+                <div key={link._id} className="border border-neutral-100 rounded-lg p-4 bg-white shadow-sm hover:shadow-md transition-shadow">
+                  <div className="flex justify-between items-start mb-3">
+                    <div className="max-w-[70%]">
+                      <div className="font-medium text-black truncate" title={link.title || link.slug}>
                         {link.title || link.slug}
                       </div>
                       <div className="text-xs text-neutral-500 flex items-center mt-1 break-all">
@@ -225,25 +315,39 @@ export default function ShortLinksDashboard() {
                           <i className="fas fa-copy"></i>
                         </button>
                       </div>
-                    </td>
-                    <td className="py-4 px-4 max-w-xs truncate text-sm text-neutral-600">
-                      <a
-                        href={link.destination}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="hover:underline"
-                      >
-                        {link.destination}
-                      </a>
-                    </td>
-                    <td className="py-4 px-4 text-sm font-medium">{link.totalClicks}</td>
-                    <td className="py-4 px-4 text-right space-x-2">
+                    </div>
+                    <Badge
+                      variant="tag"
+                      className={
+                        link.isActive ? 'bg-green-100 text-green-800 shrink-0' : 'bg-red-100 text-red-800 shrink-0'
+                      }
+                    >
+                      {link.isActive ? 'Active' : 'Inactive'}
+                    </Badge>
+                  </div>
+
+                  <div className="mb-3 text-sm text-neutral-600 truncate">
+                    <a
+                      href={link.destination}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="hover:underline flex items-center gap-1"
+                    >
+                      <i className="fas fa-link text-xs opacity-50"></i>
+                      <span className="truncate">{link.destination}</span>
+                    </a>
+                  </div>
+
+                  <div className="flex justify-between items-center pt-3 border-t border-neutral-50">
+                    <div className="text-sm">
+                      <span className="font-medium">{link.totalClicks}</span> <span className="text-neutral-500">clicks</span>
+                    </div>
+                    <div className="flex space-x-2">
                       <Link href={`/admin/short-links/${link.slug}`}>
                         <Button variant="outline" size="sm" className="px-2 py-1 h-8">
                           <i className="fas fa-chart-bar"></i>
                         </Button>
                       </Link>
-                      {/* Space reserved for future QR Code feature */}
                       <Button
                         variant="outline"
                         size="sm"
@@ -260,11 +364,11 @@ export default function ShortLinksDashboard() {
                       >
                         <i className="fas fa-trash"></i>
                       </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
         )}
       </Card>


### PR DESCRIPTION
This redesign targets the `/admin/short-links` and `/admin/short-links/[slug]` pages to be fully mobile responsive. 

On the main short links dashboard:
- It eliminates the horizontal-scroll-only table on small screens, replacing the table rows with a responsive, card-based stacked layout. 
- Skeleton loaders were updated to match this new layout. 
- Desktop users still see the standard table. 

On the analytics page:
- Padding inside cards was reduced on smaller screens.
- Typography was scaled for mobile (`text-base md:text-lg`).
- The `actionButton` container (with the Back button and the Date select) now correctly flex wraps on small screens. 
- Long labels like referrers and campaigns truncate correctly to prevent layout breakage.

---
*PR created automatically by Jules for task [11468117519285107136](https://jules.google.com/task/11468117519285107136) started by @hasanraiyan*