### PR TITLE
Update SmallClaw icon position

### DIFF
--- a/src/app/(admin)/admin/agents/page.js
+++ b/src/app/(admin)/admin/agents/page.js
@@ -522,7 +522,10 @@ export default function AgentsDashboard() {
       {/* Page Header */}
       <div className="border-b border-neutral-200 pb-8">
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
-          <h1 className="text-4xl font-bold text-black font-['Playfair_Display']">SmallClaw 🦞</h1>
+          <h1 className="text-4xl font-bold text-black font-['Playfair_Display'] flex items-center gap-2">
+            <span>🦞</span>
+            SmallClaw
+          </h1>
 
           {/* Search */}
           <div className="w-full md:w-80 lg:w-96">

--- a/src/app/(admin)/admin/layout.js
+++ b/src/app/(admin)/admin/layout.js
@@ -60,7 +60,13 @@ function AdminLayoutContent({ children }) {
       title: 'Apps',
       items: [
         { name: 'SnapLinks', href: '/admin/short-links', icon: LinkIcon },
-        { name: 'SmallClaw 🦞', href: '/admin/agents', icon: Brain },
+        {
+          name: 'SmallClaw',
+          href: '/admin/agents',
+          icon: ({ className }) => (
+            <span className={`flex items-center justify-center ${className}`}>🦞</span>
+          ),
+        },
         { name: 'Prisma', href: '/admin/media', icon: Image },
       ],
     },

--- a/src/app/(admin)/admin/short-links/[slug]/page.js
+++ b/src/app/(admin)/admin/short-links/[slug]/page.js
@@ -231,7 +231,9 @@ export default function ShortLinkAnalyticsPage() {
           <h3 className="text-xs md:text-sm font-medium text-neutral-500 uppercase tracking-wider">
             Total Clicks
           </h3>
-          <p className="text-2xl md:text-3xl font-bold mt-2 font-['Playfair_Display']">{summary.totalClicks}</p>
+          <p className="text-2xl md:text-3xl font-bold mt-2 font-['Playfair_Display']">
+            {summary.totalClicks}
+          </p>
         </Card>
         <Card variant="bordered" className="p-4 md:p-6">
           <h3 className="text-xs md:text-sm font-medium text-neutral-500 uppercase tracking-wider">
@@ -242,12 +244,16 @@ export default function ShortLinkAnalyticsPage() {
           </p>
         </Card>
         <Card variant="bordered" className="p-4 md:p-6">
-          <h3 className="text-xs md:text-sm font-medium text-neutral-500 uppercase tracking-wider">Status</h3>
+          <h3 className="text-xs md:text-sm font-medium text-neutral-500 uppercase tracking-wider">
+            Status
+          </h3>
           <div className="mt-2">
             <Badge
               variant="tag"
               className={
-                linkDetails?.isActive ? 'bg-green-100 text-green-800 text-xs md:text-sm' : 'bg-red-100 text-red-800 text-xs md:text-sm'
+                linkDetails?.isActive
+                  ? 'bg-green-100 text-green-800 text-xs md:text-sm'
+                  : 'bg-red-100 text-red-800 text-xs md:text-sm'
               }
             >
               {linkDetails?.isActive ? 'Active' : 'Inactive'}
@@ -255,7 +261,9 @@ export default function ShortLinkAnalyticsPage() {
           </div>
         </Card>
         <Card variant="bordered" className="p-4 md:p-6">
-          <h3 className="text-xs md:text-sm font-medium text-neutral-500 uppercase tracking-wider">Tags</h3>
+          <h3 className="text-xs md:text-sm font-medium text-neutral-500 uppercase tracking-wider">
+            Tags
+          </h3>
           <div className="mt-2 flex flex-wrap gap-1 md:gap-2">
             {linkDetails?.tags?.length > 0 ? (
               linkDetails.tags.map((tag) => (
@@ -279,7 +287,9 @@ export default function ShortLinkAnalyticsPage() {
         variant="bordered"
         className="p-4 md:p-6 mb-8 border-2 border-transparent hover:border-black transition-all overflow-hidden"
       >
-        <h3 className="text-base md:text-lg font-bold mb-4 font-['Playfair_Display']">Clicks Over Time</h3>
+        <h3 className="text-base md:text-lg font-bold mb-4 font-['Playfair_Display']">
+          Clicks Over Time
+        </h3>
         {clicksOverTime.length > 0 ? (
           <div className="h-64 md:h-72 w-full">
             <Line data={chartData} options={chartOptions} />
@@ -287,14 +297,18 @@ export default function ShortLinkAnalyticsPage() {
         ) : (
           <div className="h-56 md:h-64 flex flex-col justify-center text-center text-neutral-400 bg-neutral-50 rounded-lg p-4">
             <i className="fas fa-chart-line text-3xl md:text-4xl mb-2"></i>
-            <p className="text-sm md:text-base">No analytics data available for the selected time range.</p>
+            <p className="text-sm md:text-base">
+              No analytics data available for the selected time range.
+            </p>
           </div>
         )}
       </Card>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 mb-8">
         <Card variant="bordered" className="p-4 md:p-6">
-          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">Top Referrers</h3>
+          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">
+            Top Referrers
+          </h3>
           {topReferrers.length > 0 ? (
             <ul className="space-y-2 md:space-y-3">
               {topReferrers.map((ref, idx) => (
@@ -302,7 +316,9 @@ export default function ShortLinkAnalyticsPage() {
                   key={idx}
                   className="flex justify-between items-center text-xs md:text-sm border-b border-neutral-100 pb-2 last:border-0"
                 >
-                  <span className="font-medium truncate max-w-[120px] md:max-w-[150px]">{ref.referrer}</span>
+                  <span className="font-medium truncate max-w-[120px] md:max-w-[150px]">
+                    {ref.referrer}
+                  </span>
                   <span className="text-neutral-500 whitespace-nowrap">{ref.count} clicks</span>
                 </li>
               ))}
@@ -313,7 +329,9 @@ export default function ShortLinkAnalyticsPage() {
         </Card>
 
         <Card variant="bordered" className="p-4 md:p-6">
-          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">Custom Sources</h3>
+          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">
+            Custom Sources
+          </h3>
           {topSources && topSources.length > 0 ? (
             <ul className="space-y-2 md:space-y-3">
               {topSources.map((src, idx) => (
@@ -337,7 +355,9 @@ export default function ShortLinkAnalyticsPage() {
         </Card>
 
         <Card variant="bordered" className="p-4 md:p-6">
-          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">UTM Campaigns</h3>
+          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">
+            UTM Campaigns
+          </h3>
           {topCampaigns && topCampaigns.length > 0 ? (
             <ul className="space-y-2 md:space-y-3">
               {topCampaigns.map((camp, idx) => (
@@ -361,7 +381,9 @@ export default function ShortLinkAnalyticsPage() {
         </Card>
 
         <Card variant="bordered" className="p-4 md:p-6">
-          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">Top Locations</h3>
+          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">
+            Top Locations
+          </h3>
           {countries.length > 0 ? (
             <ul className="space-y-2 md:space-y-3">
               {countries.map((loc, idx) => (
@@ -369,7 +391,9 @@ export default function ShortLinkAnalyticsPage() {
                   key={idx}
                   className="flex justify-between items-center text-xs md:text-sm border-b border-neutral-100 pb-2 last:border-0"
                 >
-                  <span className="font-medium truncate max-w-[120px] md:max-w-[150px]">{loc.country || 'Unknown'}</span>
+                  <span className="font-medium truncate max-w-[120px] md:max-w-[150px]">
+                    {loc.country || 'Unknown'}
+                  </span>
                   <span className="text-neutral-500 whitespace-nowrap">{loc.count} clicks</span>
                 </li>
               ))}
@@ -382,7 +406,9 @@ export default function ShortLinkAnalyticsPage() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 pb-12">
         <Card variant="bordered" className="p-4 md:p-6">
-          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">Devices</h3>
+          <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4 font-['Playfair_Display']">
+            Devices
+          </h3>
           {devices.length > 0 ? (
             <ul className="space-y-2 md:space-y-3">
               {devices.map((dev, idx) => (

--- a/src/app/(admin)/admin/short-links/page.js
+++ b/src/app/(admin)/admin/short-links/page.js
@@ -231,7 +231,9 @@ export default function ShortLinksDashboard() {
                         <Badge
                           variant="tag"
                           className={
-                            link.isActive ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+                            link.isActive
+                              ? 'bg-green-100 text-green-800'
+                              : 'bg-red-100 text-red-800'
                           }
                         >
                           {link.isActive ? 'Active' : 'Inactive'}
@@ -299,10 +301,16 @@ export default function ShortLinksDashboard() {
             {/* Mobile Cards */}
             <div className="md:hidden space-y-4">
               {links.map((link) => (
-                <div key={link._id} className="border border-neutral-100 rounded-lg p-4 bg-white shadow-sm hover:shadow-md transition-shadow">
+                <div
+                  key={link._id}
+                  className="border border-neutral-100 rounded-lg p-4 bg-white shadow-sm hover:shadow-md transition-shadow"
+                >
                   <div className="flex justify-between items-start mb-3">
                     <div className="max-w-[70%]">
-                      <div className="font-medium text-black truncate" title={link.title || link.slug}>
+                      <div
+                        className="font-medium text-black truncate"
+                        title={link.title || link.slug}
+                      >
                         {link.title || link.slug}
                       </div>
                       <div className="text-xs text-neutral-500 flex items-center mt-1 break-all">
@@ -319,7 +327,9 @@ export default function ShortLinksDashboard() {
                     <Badge
                       variant="tag"
                       className={
-                        link.isActive ? 'bg-green-100 text-green-800 shrink-0' : 'bg-red-100 text-red-800 shrink-0'
+                        link.isActive
+                          ? 'bg-green-100 text-green-800 shrink-0'
+                          : 'bg-red-100 text-red-800 shrink-0'
                       }
                     >
                       {link.isActive ? 'Active' : 'Inactive'}
@@ -340,7 +350,8 @@ export default function ShortLinksDashboard() {
 
                   <div className="flex justify-between items-center pt-3 border-t border-neutral-50">
                     <div className="text-sm">
-                      <span className="font-medium">{link.totalClicks}</span> <span className="text-neutral-500">clicks</span>
+                      <span className="font-medium">{link.totalClicks}</span>{' '}
+                      <span className="text-neutral-500">clicks</span>
                     </div>
                     <div className="flex space-x-2">
                       <Link href={`/admin/short-links/${link.slug}`}>


### PR DESCRIPTION
This updates the "SmallClaw 🦞" icon in the admin sidebar.
- Replaced the `Brain` icon in the `src/app/(admin)/admin/layout.js` sidebar with an inline `🦞` emoji icon and removed the text emoji.
- Updated the header text in `src/app/(admin)/admin/agents/page.js` to place the `🦞` icon on the left instead of the right.
- Additionally fixed linting issues formatted using `pnpm run lint --fix .`

---
*PR created automatically by Jules for task [13635445683831324412](https://jules.google.com/task/13635445683831324412) started by @hasanraiyan*