### PR TITLE
🧹 fix: log errors in empty catch blocks across AI agents

### DIFF
--- a/src/lib/agents/ai/chat-assistant-agent.js
+++ b/src/lib/agents/ai/chat-assistant-agent.js
@@ -138,7 +138,9 @@ class ChatAgent extends BaseAgent {
                     typeof tc.function.arguments === 'string'
                       ? JSON.parse(tc.function.arguments)
                       : tc.function.arguments;
-                } catch (e) {}
+                } catch (e) {
+                  this.logger.error('Failed to parse tool arguments in chat history:', e);
+                }
                 return {
                   id: tc.id || `unknown-id-${Math.random()}`,
                   name: tc.function.name || 'unknown_function',

--- a/src/lib/agents/ai/telegram-agent.js
+++ b/src/lib/agents/ai/telegram-agent.js
@@ -176,7 +176,9 @@ class TelegramAgent extends BaseAgent {
                   typeof tc.function.arguments === 'string'
                     ? JSON.parse(tc.function.arguments)
                     : tc.function.arguments;
-              } catch (e) {}
+              } catch (e) {
+                this.logger.error('Failed to parse tool arguments in chat history:', e);
+              }
               return {
                 id: tc.id || `unknown-id-${Math.random()}`,
                 name: tc.function.name || 'unknown_function',

--- a/src/lib/agents/ai/whatsapp-agent.js
+++ b/src/lib/agents/ai/whatsapp-agent.js
@@ -83,7 +83,9 @@ class WhatsAppAgent extends BaseAgent {
                     typeof tc.function.arguments === 'string'
                       ? JSON.parse(tc.function.arguments)
                       : tc.function.arguments;
-                } catch (e) {}
+                } catch (e) {
+                  this.logger.error('Failed to parse tool arguments in chat history:', e);
+                }
                 return {
                   id: tc.id || `unknown-id-${Math.random()}`,
                   name: tc.function.name || 'unknown_function',


### PR DESCRIPTION
I have addressed the code health issue where empty catch blocks were silently swallowing errors during tool argument parsing in several AI agents.

### 🎯 What:
- Added `this.logger.error('Failed to parse tool arguments in chat history:', e);` to the previously empty catch blocks in:
  - `src/lib/agents/ai/telegram-agent.js`
  - `src/lib/agents/ai/chat-assistant-agent.js`
  - `src/lib/agents/ai/whatsapp-agent.js`

### 💡 Why:
- Silent failures make debugging extremely difficult. Logging the error provides visibility into potential JSON parsing or schema issues while still allowing the system to fall back to safe default values (empty object for arguments).

### ✅ Verification:
- Verified syntax using `node --check`.
- Ran existing unit tests with `node --test 'src/**/*.test.js'` (7/7 passed).
- Confirmed that `this.logger` is the standard logging pattern in these classes (inherited from `BaseAgent`).

### ✨ Result:
- Improved code observability and maintainability across the core AI agents.

---
*PR created automatically by Jules for task [12222230731794101290](https://jules.google.com/task/12222230731794101290) started by @hasanraiyan*