### PR TITLE
Support green brand theme for chatbot UI in specific contexts

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -1,0 +1,109 @@
+
+> resume@0.1.0 dev /app
+> next dev --turbopack
+
+   ▲ Next.js 15.5.9 (Turbopack)
+   - Local:        http://localhost:3000
+   - Network:      http://192.168.0.2:3000
+   - Experiments (use with caution):
+     · serverActions
+
+ ✓ Starting...
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry
+
+ ○ Compiling middleware ...
+ ✓ Compiled middleware in 599ms
+ ✓ Ready in 2s
+ ○ Compiling /pocketly ...
+ ✓ Compiled /pocketly in 21.6s
+WARNING: MONGODB_URI environment variable is not defined.
+Skipping dbConnect because MONGODB_URI is not set.
+Skipping dbConnect because MONGODB_URI is not set.
+ GET /pocketly 200 in 29999ms
+[getHeroData] Failed to fetch hero section from DB: [MongooseError: Operation `herosections.findOne()` buffering timed out after 10000ms]
+Skipping dbConnect because MONGODB_URI is not set.
+[getSiteConfig] Error: [MongooseError: Operation `siteconfigs.findOne()` buffering timed out after 10000ms]
+[getSiteConfig] Error: [MongooseError: Operation `siteconfigs.findOne()` buffering timed out after 10000ms]
+Skipping dbConnect because MONGODB_URI is not set.
+Skipping dbConnect because MONGODB_URI is not set.
+[getHeroData] Failed to fetch hero section from DB: [MongooseError: Operation `herosections.findOne()` buffering timed out after 10000ms]
+Skipping dbConnect because MONGODB_URI is not set.
+[getSiteConfig] Error: [MongooseError: Operation `siteconfigs.findOne()` buffering timed out after 10000ms]
+[getSiteConfig] Error: [MongooseError: Operation `siteconfigs.findOne()` buffering timed out after 10000ms]
+ GET /pocketly 200 in 20342ms
+ ○ Compiling /api/analytics ...
+WARNING: MONGODB_URI environment variable is not defined.
+Skipping dbConnect because MONGODB_URI is not set.
+Skipping dbConnect because MONGODB_URI is not set.
+ ✓ Compiled /api/analytics in 4.1s
+ ⨯ Error: ENCRYPTION_SECRET environment variable is required
+    at deriveKey (src/lib/crypto.js:77:11)
+    at __TURBOPACK__module__evaluation__ (src/lib/crypto.js:94:24)
+    at __TURBOPACK__module__evaluation__ (src/app/api/admin/chatbot/route.js:23:1)
+    at Object.<anonymous> (.next/server/app/api/admin/chatbot/route.js:9:3)
+  75 | function deriveKey(secret) {
+  76 |   if (!secret) {
+> 77 |     throw new Error('ENCRYPTION_SECRET environment variable is required');
+     |           ^
+  78 |   }
+  79 |
+  80 |   // If a proper hex string is provided, use it directly {
+  page: '/api/admin/chatbot'
+}
+[next-auth][warn][NEXTAUTH_URL]
+https://next-auth.js.org/warnings#nextauth_url
+[next-auth][warn][NO_SECRET]
+https://next-auth.js.org/warnings#no_secret
+Skipping dbConnect because MONGODB_URI is not set.
+Skipping dbConnect because MONGODB_URI is not set.
+ ○ Compiling /_error ...
+ GET /api/auth/session 200 in 5301ms
+ GET /api/auth/session 200 in 477ms
+ GET /api/admin/chatbot 500 in 10299ms
+ ✓ Compiled /_error in 5.8s
+Skipping dbConnect because MONGODB_URI is not set.
+ ○ Compiling / ...
+Analytics tracking error: [MongooseError: Operation `analytics.insertOne()` buffering timed out after 10000ms]
+ POST /api/analytics 500 in 12758ms
+Analytics tracking error: [MongooseError: Operation `analytics.insertOne()` buffering timed out after 10000ms]
+ POST /api/analytics 500 in 12791ms
+Skipping dbConnect because MONGODB_URI is not set.
+Error fetching dynamic MCP config: [MongooseError: Operation `mcpservers.find()` buffering timed out after 10000ms]
+ GET /api/mcps 200 in 14604ms
+Failed to fetch finance bootstrap: [MongooseError: Operation `accounts.find()` buffering timed out after 10000ms]
+ GET /api/money/bootstrap?startDate=2026-04-06T00%3A00%3A00.000Z&endDate=2026-04-12T23%3A59%3A59.999Z 500 in 14713ms
+Skipping dbConnect because MONGODB_URI is not set.
+Skipping dbConnect because MONGODB_URI is not set.
+ ✓ Compiled / in 8s
+ ⨯ Error: ENCRYPTION_SECRET environment variable is required
+    at deriveKey (src/lib/crypto.js:77:11)
+    at __TURBOPACK__module__evaluation__ (src/lib/crypto.js:94:24)
+    at __TURBOPACK__module__evaluation__ (src/app/actions/contactActions.js:11:1)
+    at __TURBOPACK__module__evaluation__ (.next-internal/server/app/page/actions.js (server actions loader):40:1)
+    at __TURBOPACK__module__evaluation__ (.next/server/chunks/ssr/[root-of-the-server]__a4064c7d._.js:3917:2440)
+    at Object.<anonymous> (.next/server/app/page.js:17:3)
+  75 | function deriveKey(secret) {
+  76 |   if (!secret) {
+> 77 |     throw new Error('ENCRYPTION_SECRET environment variable is required');
+     |           ^
+  78 |   }
+  79 |
+  80 |   // If a proper hex string is provided, use it directly {
+  page: '/'
+}
+ GET / 500 in 8625ms
+ GET /3D.png 404 in 7117ms
+[getSiteConfig] Error: [MongooseError: Operation `siteconfigs.findOne()` buffering timed out after 10000ms]
+ GET /login 200 in 14996ms
+Analytics tracking error: [MongooseError: Operation `analytics.insertOne()` buffering timed out after 10000ms]
+ POST /api/analytics 500 in 10392ms
+[getHeroData] Failed to fetch hero section from DB: [MongooseError: Operation `herosections.findOne()` buffering timed out after 10000ms]
+Skipping dbConnect because MONGODB_URI is not set.
+[getSiteConfig] Error: [MongooseError: Operation `siteconfigs.findOne()` buffering timed out after 10000ms]
+Skipping dbConnect because MONGODB_URI is not set.
+ POST /api/analytics 200 in 2014ms
+[getSiteConfig] Error: [MongooseError: Operation `siteconfigs.findOne()` buffering timed out after 10000ms]
+Analytics tracking error: [MongooseError: Operation `analytics.insertOne()` buffering timed out after 10000ms]

--- a/src/components/chatbot/ChatInput.js
+++ b/src/components/chatbot/ChatInput.js
@@ -24,7 +24,9 @@ export default function ChatInput({
   selectedAgentId,
   setSelectedAgentId,
   showModelSelector = true,
+  theme = 'default',
 }) {
+  const isGreenTheme = theme === 'green';
   return (
     <div className="p-3 border-t border-neutral-200/50 bg-white shrink-0">
       <div className="rounded-3xl border border-neutral-200/80 bg-white shadow-sm focus-within:border-black/50 focus-within:ring-1 focus-within:ring-black/20 transition-all flex flex-col">
@@ -86,7 +88,7 @@ export default function ChatInput({
                 type="button"
                 onClick={handleSubmit}
                 disabled={isLoading}
-                className="w-8 h-8 rounded-full flex items-center justify-center transition-all bg-black text-white hover:opacity-90 active:scale-95"
+                className={`w-8 h-8 rounded-full flex items-center justify-center transition-all ${isGreenTheme ? 'bg-[#1f644e] text-white hover:bg-[#1a5542]' : 'bg-black text-white hover:opacity-90'} active:scale-95`}
               >
                 {isLoading ? (
                   <span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" />

--- a/src/components/chatbot/MessageList.js
+++ b/src/components/chatbot/MessageList.js
@@ -8,7 +8,10 @@ export default function MessageList({
   messagesEndRef,
   handleUIInteract,
   handleLinkClick,
+  theme = 'default',
 }) {
+  const isGreenTheme = theme === 'green';
+
   return (
     <div className="flex-1 overflow-y-auto overflow-x-hidden p-3 sm:p-5 space-y-3 bg-gradient-to-b from-white/50 to-neutral-50/50 custom-chat-scrollbar">
       {messages.map((message, index) => {
@@ -37,7 +40,7 @@ export default function MessageList({
             <div className="relative w-7 h-7 shrink-0 mt-1 flex items-center justify-center">
               {!isConsecutive && (
                 <div
-                  className={`w-full h-full rounded-full flex items-center justify-center shadow-sm ${message.role === 'user' ? 'bg-black ring-2 ring-black/10' : 'bg-neutral-100 border border-neutral-200/60'}`}
+                  className={`w-full h-full rounded-full flex items-center justify-center shadow-sm ${message.role === 'user' ? (isGreenTheme ? 'bg-[#1f644e] ring-2 ring-[#1f644e]/10' : 'bg-black ring-2 ring-black/10') : 'bg-neutral-100 border border-neutral-200/60'}`}
                 >
                   {message.role === 'user' ? (
                     <User className="w-3.5 h-3.5 text-white" />
@@ -72,7 +75,7 @@ export default function MessageList({
                 <div
                   className={`${
                     isAssistant && message.uiBlocks?.length > 0 ? 'mt-3' : ''
-                  } px-3.5 sm:px-4 py-2.5 sm:py-3 rounded-2xl shadow-sm text-[13px] overflow-hidden ${message.role === 'user' ? 'bg-gradient-to-br from-black to-neutral-900 text-white shadow-black/20 rounded-tr-sm' : 'bg-white/90 backdrop-blur-sm text-neutral-900 shadow-neutral-200/50 border border-neutral-200/50 rounded-tl-sm'}`}
+                  } px-3.5 sm:px-4 py-2.5 sm:py-3 rounded-2xl shadow-sm text-[13px] overflow-hidden ${message.role === 'user' ? (isGreenTheme ? 'bg-[#1f644e] text-white shadow-[#1f644e]/20 rounded-tr-sm' : 'bg-gradient-to-br from-black to-neutral-900 text-white shadow-black/20 rounded-tr-sm') : 'bg-white/90 backdrop-blur-sm text-neutral-900 shadow-neutral-200/50 border border-neutral-200/50 rounded-tl-sm'}`}
                 >
                   {message.role === 'assistant' ? (
                     <MdContent content={message.content} onLinkClick={handleLinkClick} />

--- a/src/components/pocketly-tracker/ChatTab.js
+++ b/src/components/pocketly-tracker/ChatTab.js
@@ -70,6 +70,7 @@ export default function ChatTab() {
           messagesEndRef={messagesEndRef}
           handleUIInteract={handleUIInteract}
           handleLinkClick={() => {}}
+          theme="green"
         />
       </div>
 
@@ -94,6 +95,7 @@ export default function ChatTab() {
         selectedAgentId={selectedAgentId}
         setSelectedAgentId={setSelectedAgentId}
         showModelSelector={false}
+        theme="green"
       />
     </div>
   );

--- a/src/components/pocketly-tracker/FinanceAgentPanel.js
+++ b/src/components/pocketly-tracker/FinanceAgentPanel.js
@@ -218,7 +218,7 @@ export default function FinanceAgentPanel({ activeTab }) {
           <button
             type="submit"
             disabled={!inputMessage.trim()}
-            className="flex h-8 w-8 items-center justify-center rounded-full bg-black text-white transition-all hover:opacity-90 active:scale-95 disabled:cursor-default disabled:bg-neutral-200 disabled:text-neutral-400"
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-[#1f644e] text-white transition-all hover:bg-[#1a5542] active:scale-95 disabled:cursor-default disabled:bg-neutral-200 disabled:text-neutral-400"
           >
             <Send className="h-4 w-4" />
           </button>
@@ -238,6 +238,7 @@ export default function FinanceAgentPanel({ activeTab }) {
           messagesEndRef={messagesEndRef}
           handleUIInteract={() => {}}
           handleLinkClick={() => {}}
+          theme="green"
         />
         {financeInput}
       </div>


### PR DESCRIPTION
This commit updates the chatbot UI components to optionally use a green brand theme (`#1f644e`) instead of the default black. This addresses the request to make the user message bubbles and send buttons match the application's green aesthetic when used inside specific modules (like Pocketly). The changes preserve the original black style when the `theme` prop is not passed, allowing the components to continue to be shared appropriately across different contexts.

---
*PR created automatically by Jules for task [10471724660552691073](https://jules.google.com/task/10471724660552691073) started by @hasanraiyan*