### PR TITLE
feat(pocketly): add draft transaction tool to finance assistant

### DIFF
--- a/src/components/pocketly-tracker/ChatTab.js
+++ b/src/components/pocketly-tracker/ChatTab.js
@@ -8,7 +8,7 @@ import ChatInput from '@/components/chatbot/ChatInput';
 
 export default function ChatTab() {
   const { messages, sendMessage, isStreaming } = useFinanceChat();
-  const { setActiveTab } = useMoney();
+  const { setActiveTab, addTransaction } = useMoney();
   const [inputMessage, setInputMessage] = useState('');
   const messagesEndRef = useRef(null);
   const inputRef = useRef(null);
@@ -52,19 +52,47 @@ export default function ChatTab() {
     }
   };
 
-  const handleUIInteract = (action) => {
+  const handleUIInteract = async (action) => {
     if (!action) return;
 
     if (action.type === 'switch_tab' && action.tab) {
       setActiveTab(action.tab);
     }
 
-    if (action.type === 'confirm_transaction' || action.type === 'cancel_transaction') {
-      sendMessage(
-        action.type === 'confirm_transaction'
-          ? `I confirm the transaction: ${JSON.stringify(action.data)}. Please use the add_transaction tool again with the EXACT same data but set isConfirmed=true to save it to the database.`
-          : 'I want to cancel or edit this transaction manually.'
-      );
+    if (action.type === 'confirm_transaction') {
+      const { data, setLocalState } = action;
+      if (setLocalState) setLocalState('saving');
+
+      try {
+        const payload = {
+          type: data.type,
+          amount: data.amount,
+          description: data.description,
+          account: data.accountId,
+          date: data.date ? new Date(data.date).toISOString() : new Date().toISOString(),
+        };
+
+        if (data.type === 'transfer') {
+          payload.toAccount = data.toAccountId;
+        } else {
+          payload.category = data.categoryId;
+        }
+
+        await addTransaction(payload);
+
+        if (setLocalState) {
+          setLocalState('success');
+        } else {
+          sendMessage('Transaction confirmed and saved successfully!');
+        }
+      } catch (err) {
+        if (setLocalState) setLocalState('error');
+        sendMessage('Sorry, there was an error saving the transaction.');
+      }
+    }
+
+    if (action.type === 'cancel_transaction') {
+      sendMessage('I want to cancel or edit this transaction manually.');
     }
   };
 

--- a/src/components/pocketly-tracker/ChatTab.js
+++ b/src/components/pocketly-tracker/ChatTab.js
@@ -62,7 +62,7 @@ export default function ChatTab() {
     if (action.type === 'confirm_transaction' || action.type === 'cancel_transaction') {
       sendMessage(
         action.type === 'confirm_transaction'
-          ? `I confirm the transaction: ${JSON.stringify(action.data)}`
+          ? `I confirm the transaction: ${JSON.stringify(action.data)}. Please use the add_transaction tool again with the EXACT same data but set isConfirmed=true to save it to the database.`
           : 'I want to cancel or edit this transaction manually.'
       );
     }

--- a/src/components/pocketly-tracker/ChatTab.js
+++ b/src/components/pocketly-tracker/ChatTab.js
@@ -58,6 +58,14 @@ export default function ChatTab() {
     if (action.type === 'switch_tab' && action.tab) {
       setActiveTab(action.tab);
     }
+
+    if (action.type === 'confirm_transaction' || action.type === 'cancel_transaction') {
+      sendMessage(
+        action.type === 'confirm_transaction'
+          ? `I confirm the transaction: ${JSON.stringify(action.data)}`
+          : 'I want to cancel or edit this transaction manually.'
+      );
+    }
   };
 
   return (

--- a/src/components/pocketly-tracker/FinanceChatBlockRenderer.js
+++ b/src/components/pocketly-tracker/FinanceChatBlockRenderer.js
@@ -329,5 +329,76 @@ export default function FinanceChatBlockRenderer({ block, onInteract }) {
     return <CategoryBreakdownBlock block={block} onInteract={onInteract} />;
   }
 
+  if (block.kind === 'transaction_confirmation') {
+    return <TransactionConfirmationBlock block={block} onInteract={onInteract} />;
+  }
+
   return null;
+}
+
+function TransactionConfirmationBlock({ block, onInteract }) {
+  const data = block.data || {};
+  const isExpense = data.type === 'expense';
+  const isTransfer = data.type === 'transfer';
+
+  const amountColor = isExpense ? 'text-[#c94c4c]' : isTransfer ? 'text-[#1e3a34]' : 'text-[#1f644e]';
+  const amountPrefix = isExpense ? '-' : isTransfer ? '' : '+';
+
+  return (
+    <div className="rounded-2xl border border-neutral-200/70 bg-[#f8f8f4] p-3 shadow-sm">
+      <p className="text-xs font-semibold text-neutral-800 mb-3">{block.title || 'Confirm Transaction'}</p>
+
+      <div className="rounded-xl border border-neutral-200 bg-white p-3 space-y-3">
+        <div className="flex justify-between items-start gap-4 border-b border-neutral-100 pb-3">
+           <div>
+             <p className="text-sm font-semibold text-neutral-900">{data.description || 'Draft Transaction'}</p>
+             <p className="text-[11px] text-neutral-500 capitalize">{data.type}</p>
+           </div>
+           <p className={`text-sm font-bold shrink-0 ${amountColor}`}>
+              {amountPrefix}{formatCurrency(data.amount)}
+           </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2 text-xs">
+          <div>
+            <p className="text-[10px] uppercase text-neutral-400 font-semibold mb-0.5">Date</p>
+            <p className="font-medium text-neutral-800">{data.date || 'Today'}</p>
+          </div>
+          {!isTransfer && (
+            <div>
+              <p className="text-[10px] uppercase text-neutral-400 font-semibold mb-0.5">Category</p>
+              <p className="font-medium text-neutral-800">{data.categoryHint || 'Uncategorized'}</p>
+            </div>
+          )}
+          <div>
+            <p className="text-[10px] uppercase text-neutral-400 font-semibold mb-0.5">Account</p>
+            <p className="font-medium text-neutral-800">{data.accountHint || 'Select later'}</p>
+          </div>
+          {isTransfer && (
+             <div>
+              <p className="text-[10px] uppercase text-neutral-400 font-semibold mb-0.5">To Account</p>
+              <p className="font-medium text-neutral-800">{data.toAccountHint || 'Select later'}</p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex gap-2 mt-3">
+        <button
+          type="button"
+          onClick={() => onInteract?.({ type: 'confirm_transaction', data })}
+          className="flex-1 cursor-pointer rounded-full bg-[#1e3a34] px-3 py-2 text-xs font-semibold text-white transition hover:bg-[#152924]"
+        >
+          Confirm
+        </button>
+        <button
+          type="button"
+          onClick={() => onInteract?.({ type: 'cancel_transaction', data })}
+          className="flex-1 cursor-pointer rounded-full border border-neutral-200 bg-white px-3 py-2 text-xs font-semibold text-neutral-700 transition hover:bg-neutral-50"
+        >
+          Edit Manually
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/src/components/pocketly-tracker/FinanceChatBlockRenderer.js
+++ b/src/components/pocketly-tracker/FinanceChatBlockRenderer.js
@@ -378,19 +378,19 @@ function TransactionConfirmationBlock({ block, onInteract }) {
               <p className="text-[10px] uppercase text-neutral-400 font-semibold mb-0.5">
                 Category
               </p>
-              <p className="font-medium text-neutral-800">{data.categoryHint || 'Uncategorized'}</p>
+              <p className="font-medium text-neutral-800">{data.categoryName || 'Uncategorized'}</p>
             </div>
           )}
           <div>
             <p className="text-[10px] uppercase text-neutral-400 font-semibold mb-0.5">Account</p>
-            <p className="font-medium text-neutral-800">{data.accountHint || 'Select later'}</p>
+            <p className="font-medium text-neutral-800">{data.accountName || 'Select later'}</p>
           </div>
           {isTransfer && (
             <div>
               <p className="text-[10px] uppercase text-neutral-400 font-semibold mb-0.5">
                 To Account
               </p>
-              <p className="font-medium text-neutral-800">{data.toAccountHint || 'Select later'}</p>
+              <p className="font-medium text-neutral-800">{data.toAccountName || 'Select later'}</p>
             </div>
           )}
         </div>

--- a/src/components/pocketly-tracker/FinanceChatBlockRenderer.js
+++ b/src/components/pocketly-tracker/FinanceChatBlockRenderer.js
@@ -341,22 +341,31 @@ function TransactionConfirmationBlock({ block, onInteract }) {
   const isExpense = data.type === 'expense';
   const isTransfer = data.type === 'transfer';
 
-  const amountColor = isExpense ? 'text-[#c94c4c]' : isTransfer ? 'text-[#1e3a34]' : 'text-[#1f644e]';
+  const amountColor = isExpense
+    ? 'text-[#c94c4c]'
+    : isTransfer
+      ? 'text-[#1e3a34]'
+      : 'text-[#1f644e]';
   const amountPrefix = isExpense ? '-' : isTransfer ? '' : '+';
 
   return (
     <div className="rounded-2xl border border-neutral-200/70 bg-[#f8f8f4] p-3 shadow-sm">
-      <p className="text-xs font-semibold text-neutral-800 mb-3">{block.title || 'Confirm Transaction'}</p>
+      <p className="text-xs font-semibold text-neutral-800 mb-3">
+        {block.title || 'Confirm Transaction'}
+      </p>
 
       <div className="rounded-xl border border-neutral-200 bg-white p-3 space-y-3">
         <div className="flex justify-between items-start gap-4 border-b border-neutral-100 pb-3">
-           <div>
-             <p className="text-sm font-semibold text-neutral-900">{data.description || 'Draft Transaction'}</p>
-             <p className="text-[11px] text-neutral-500 capitalize">{data.type}</p>
-           </div>
-           <p className={`text-sm font-bold shrink-0 ${amountColor}`}>
-              {amountPrefix}{formatCurrency(data.amount)}
-           </p>
+          <div>
+            <p className="text-sm font-semibold text-neutral-900">
+              {data.description || 'Draft Transaction'}
+            </p>
+            <p className="text-[11px] text-neutral-500 capitalize">{data.type}</p>
+          </div>
+          <p className={`text-sm font-bold shrink-0 ${amountColor}`}>
+            {amountPrefix}
+            {formatCurrency(data.amount)}
+          </p>
         </div>
 
         <div className="grid grid-cols-2 gap-2 text-xs">
@@ -366,7 +375,9 @@ function TransactionConfirmationBlock({ block, onInteract }) {
           </div>
           {!isTransfer && (
             <div>
-              <p className="text-[10px] uppercase text-neutral-400 font-semibold mb-0.5">Category</p>
+              <p className="text-[10px] uppercase text-neutral-400 font-semibold mb-0.5">
+                Category
+              </p>
               <p className="font-medium text-neutral-800">{data.categoryHint || 'Uncategorized'}</p>
             </div>
           )}
@@ -375,8 +386,10 @@ function TransactionConfirmationBlock({ block, onInteract }) {
             <p className="font-medium text-neutral-800">{data.accountHint || 'Select later'}</p>
           </div>
           {isTransfer && (
-             <div>
-              <p className="text-[10px] uppercase text-neutral-400 font-semibold mb-0.5">To Account</p>
+            <div>
+              <p className="text-[10px] uppercase text-neutral-400 font-semibold mb-0.5">
+                To Account
+              </p>
               <p className="font-medium text-neutral-800">{data.toAccountHint || 'Select later'}</p>
             </div>
           )}

--- a/src/lib/agents/ai/finance-assistant-agent.js
+++ b/src/lib/agents/ai/finance-assistant-agent.js
@@ -77,7 +77,7 @@ function getToolLabel(toolName) {
     get_transactions: 'Reviewing transactions',
     get_accounts: 'Checking accounts',
     get_categories: 'Reviewing categories',
-    draft_transaction: 'Drafting transaction',
+    add_transaction: 'Drafting transaction',
   };
 
   return labels[toolName] || `Using ${toolName}`;
@@ -162,7 +162,7 @@ function buildUiBlocks(toolName, output) {
     ];
   }
 
-  if (toolName === 'draft_transaction') {
+  if (toolName === 'add_transaction' && parsed.isConfirmed === false) {
     return [
       {
         kind: 'transaction_confirmation',

--- a/src/lib/agents/ai/finance-assistant-agent.js
+++ b/src/lib/agents/ai/finance-assistant-agent.js
@@ -77,6 +77,7 @@ function getToolLabel(toolName) {
     get_transactions: 'Reviewing transactions',
     get_accounts: 'Checking accounts',
     get_categories: 'Reviewing categories',
+    draft_transaction: 'Drafting transaction',
   };
 
   return labels[toolName] || `Using ${toolName}`;
@@ -157,6 +158,17 @@ function buildUiBlocks(toolName, output) {
           income,
           expense,
         },
+      },
+    ];
+  }
+
+  if (toolName === 'draft_transaction') {
+    return [
+      {
+        kind: 'transaction_confirmation',
+        title: 'Confirm Transaction',
+        action: null,
+        data: parsed,
       },
     ];
   }

--- a/src/lib/agents/ai/finance-assistant-agent.js
+++ b/src/lib/agents/ai/finance-assistant-agent.js
@@ -77,7 +77,7 @@ function getToolLabel(toolName) {
     get_transactions: 'Reviewing transactions',
     get_accounts: 'Checking accounts',
     get_categories: 'Reviewing categories',
-    add_transaction: 'Drafting transaction',
+    draft_transaction: 'Drafting transaction',
   };
 
   return labels[toolName] || `Using ${toolName}`;
@@ -162,7 +162,7 @@ function buildUiBlocks(toolName, output) {
     ];
   }
 
-  if (toolName === 'add_transaction' && parsed.isConfirmed === false) {
+  if (toolName === 'draft_transaction') {
     return [
       {
         kind: 'transaction_confirmation',

--- a/src/lib/agents/memory/LongTermMemoryService.js
+++ b/src/lib/agents/memory/LongTermMemoryService.js
@@ -411,11 +411,11 @@ function mergeProfiles(existingProfile = {}, nextProfile = {}) {
 function hasProfileContent(profile = {}) {
   return Boolean(
     profile.summary ||
-      profile.facts?.length ||
-      profile.preferences?.length ||
-      profile.goals?.length ||
-      profile.constraints?.length ||
-      profile.topics?.length
+    profile.facts?.length ||
+    profile.preferences?.length ||
+    profile.goals?.length ||
+    profile.constraints?.length ||
+    profile.topics?.length
   );
 }
 

--- a/src/lib/agents/utils/finance-tools.js
+++ b/src/lib/agents/utils/finance-tools.js
@@ -238,11 +238,35 @@ export function createGetAnalysisTool() {
   );
 }
 
+export function createDraftTransactionTool() {
+  return tool(
+    async (params) => {
+      // Just echo back the parameters so the UI can render a confirmation card
+      return JSON.stringify(params);
+    },
+    {
+      name: 'draft_transaction',
+      description:
+        'Draft a new transaction based on the user\'s natural language input. Use this when the user says they spent money, earned money, or transferred money. This will show a confirmation UI to the user before saving.',
+      schema: z.object({
+        type: z.enum(['income', 'expense', 'transfer']).describe('The type of transaction'),
+        amount: z.number().describe('The amount of the transaction'),
+        description: z.string().describe('A short description of the transaction'),
+        categoryHint: z.string().optional().describe('A hint for the category (e.g. "Food", "Salary") if applicable'),
+        accountHint: z.string().optional().describe('A hint for the account to use (e.g. "Cash", "Credit Card")'),
+        toAccountHint: z.string().optional().describe('A hint for the destination account (only for transfers)'),
+        date: z.string().optional().describe('The date of the transaction in YYYY-MM-DD format. Default is today.'),
+      }),
+    }
+  );
+}
+
 export function createFinanceTools() {
   return [
     createGetAccountsTool(),
     createGetCategoriesTool(),
     createGetTransactionsTool(),
     createGetAnalysisTool(),
+    createDraftTransactionTool(),
   ];
 }

--- a/src/lib/agents/utils/finance-tools.js
+++ b/src/lib/agents/utils/finance-tools.js
@@ -238,39 +238,55 @@ export function createGetAnalysisTool() {
   );
 }
 
-export function createDraftTransactionTool() {
+export function createAddTransactionTool() {
   return tool(
     async (params) => {
-      // Just echo back the parameters so the UI can render a confirmation card
-      return JSON.stringify(params);
+      if (!params.isConfirmed) {
+        // Return the draft payload to render the UI confirmation card
+        return JSON.stringify(params);
+      }
+
+      // If confirmed, actually save to the DB
+      await ensureDb();
+
+      const transactionData = {
+        type: params.type,
+        amount: params.amount,
+        description: params.description,
+        account: params.accountId,
+        date: params.date ? new Date(params.date) : new Date(),
+      };
+
+      if (params.type === 'transfer') {
+        transactionData.toAccount = params.toAccountId;
+      } else {
+        transactionData.category = params.categoryId;
+      }
+
+      const newTransaction = await Transaction.create(transactionData);
+
+      return JSON.stringify({
+        success: true,
+        message: 'Transaction saved successfully',
+        transactionId: newTransaction._id.toString()
+      });
     },
     {
-      name: 'draft_transaction',
+      name: 'add_transaction',
       description:
-        "Draft a new transaction based on the user's natural language input. Use this when the user says they spent money, earned money, or transferred money. This will show a confirmation UI to the user before saving.",
+        'Add a new transaction (income, expense, or transfer). YOU MUST FIRST USE get_accounts and get_categories tools to find the exact accountId and categoryId. If the user has not explicitly confirmed yet, call this with isConfirmed=false to show a draft UI. Once the user says "I confirm the transaction", call this tool again with the exact same data but isConfirmed=true to save it to the database.',
       schema: z.object({
+        isConfirmed: z.boolean().describe('Set to false to draft the transaction for user approval. Set to true ONLY when the user explicitly confirms the draft.'),
         type: z.enum(['income', 'expense', 'transfer']).describe('The type of transaction'),
-        amount: z
-          .number()
-          .positive()
-          .describe('The absolute amount of the transaction (must be positive)'),
+        amount: z.number().positive().describe('The absolute amount of the transaction (must be positive)'),
         description: z.string().describe('A short description of the transaction'),
-        categoryHint: z
-          .string()
-          .optional()
-          .describe('A hint for the category (e.g. "Food", "Salary") if applicable'),
-        accountHint: z
-          .string()
-          .optional()
-          .describe('A hint for the account to use (e.g. "Cash", "Credit Card")'),
-        toAccountHint: z
-          .string()
-          .optional()
-          .describe('A hint for the destination account (only for transfers)'),
-        date: z
-          .string()
-          .optional()
-          .describe('The date of the transaction in YYYY-MM-DD format. Default is today.'),
+        accountId: z.string().describe('The exact MongoDB ID of the source account'),
+        accountName: z.string().describe('The display name of the source account (for UI purposes)'),
+        categoryId: z.string().optional().describe('The exact MongoDB ID of the category (Required for income/expense)'),
+        categoryName: z.string().optional().describe('The display name of the category (for UI purposes)'),
+        toAccountId: z.string().optional().describe('The exact MongoDB ID of the destination account (Required ONLY for transfers)'),
+        toAccountName: z.string().optional().describe('The display name of the destination account (for UI purposes)'),
+        date: z.string().optional().describe('The date of the transaction in YYYY-MM-DD format. Default is today.'),
       }),
     }
   );
@@ -282,6 +298,6 @@ export function createFinanceTools() {
     createGetCategoriesTool(),
     createGetTransactionsTool(),
     createGetAnalysisTool(),
-    createDraftTransactionTool(),
+    createAddTransactionTool(),
   ];
 }

--- a/src/lib/agents/utils/finance-tools.js
+++ b/src/lib/agents/utils/finance-tools.js
@@ -247,15 +247,30 @@ export function createDraftTransactionTool() {
     {
       name: 'draft_transaction',
       description:
-        'Draft a new transaction based on the user\'s natural language input. Use this when the user says they spent money, earned money, or transferred money. This will show a confirmation UI to the user before saving.',
+        "Draft a new transaction based on the user's natural language input. Use this when the user says they spent money, earned money, or transferred money. This will show a confirmation UI to the user before saving.",
       schema: z.object({
         type: z.enum(['income', 'expense', 'transfer']).describe('The type of transaction'),
-        amount: z.number().describe('The amount of the transaction'),
+        amount: z
+          .number()
+          .positive()
+          .describe('The absolute amount of the transaction (must be positive)'),
         description: z.string().describe('A short description of the transaction'),
-        categoryHint: z.string().optional().describe('A hint for the category (e.g. "Food", "Salary") if applicable'),
-        accountHint: z.string().optional().describe('A hint for the account to use (e.g. "Cash", "Credit Card")'),
-        toAccountHint: z.string().optional().describe('A hint for the destination account (only for transfers)'),
-        date: z.string().optional().describe('The date of the transaction in YYYY-MM-DD format. Default is today.'),
+        categoryHint: z
+          .string()
+          .optional()
+          .describe('A hint for the category (e.g. "Food", "Salary") if applicable'),
+        accountHint: z
+          .string()
+          .optional()
+          .describe('A hint for the account to use (e.g. "Cash", "Credit Card")'),
+        toAccountHint: z
+          .string()
+          .optional()
+          .describe('A hint for the destination account (only for transfers)'),
+        date: z
+          .string()
+          .optional()
+          .describe('The date of the transaction in YYYY-MM-DD format. Default is today.'),
       }),
     }
   );

--- a/src/lib/agents/utils/finance-tools.js
+++ b/src/lib/agents/utils/finance-tools.js
@@ -238,55 +238,53 @@ export function createGetAnalysisTool() {
   );
 }
 
-export function createAddTransactionTool() {
+export function createDraftTransactionTool() {
   return tool(
     async (params) => {
-      if (!params.isConfirmed) {
-        // Return the draft payload to render the UI confirmation card
-        return JSON.stringify(params);
-      }
-
-      // If confirmed, actually save to the DB
-      await ensureDb();
-
-      const transactionData = {
-        type: params.type,
-        amount: params.amount,
-        description: params.description,
-        account: params.accountId,
-        date: params.date ? new Date(params.date) : new Date(),
-      };
-
-      if (params.type === 'transfer') {
-        transactionData.toAccount = params.toAccountId;
-      } else {
-        transactionData.category = params.categoryId;
-      }
-
-      const newTransaction = await Transaction.create(transactionData);
-
-      return JSON.stringify({
-        success: true,
-        message: 'Transaction saved successfully',
-        transactionId: newTransaction._id.toString()
-      });
+      // Return the draft payload to render the UI confirmation card
+      return JSON.stringify(params);
     },
     {
-      name: 'add_transaction',
+      name: 'draft_transaction',
       description:
-        'Add a new transaction (income, expense, or transfer). YOU MUST FIRST USE get_accounts and get_categories tools to find the exact accountId and categoryId. If the user has not explicitly confirmed yet, call this with isConfirmed=false to show a draft UI. Once the user says "I confirm the transaction", call this tool again with the exact same data but isConfirmed=true to save it to the database.',
+        'Draft a new transaction (income, expense, or transfer). YOU MUST FIRST USE get_accounts and get_categories tools to find the exact accountId and categoryId. This will show a confirmation UI to the user, where the user can save it directly.',
       schema: z.object({
-        isConfirmed: z.boolean().describe('Set to false to draft the transaction for user approval. Set to true ONLY when the user explicitly confirms the draft.'),
         type: z.enum(['income', 'expense', 'transfer']).describe('The type of transaction'),
-        amount: z.number().positive().describe('The absolute amount of the transaction (must be positive)'),
+        amount: z
+          .number()
+          .positive()
+          .describe('The absolute amount of the transaction (must be positive)'),
         description: z.string().describe('A short description of the transaction'),
         accountId: z.string().describe('The exact MongoDB ID of the source account'),
-        accountName: z.string().describe('The display name of the source account (for UI purposes)'),
-        categoryId: z.string().optional().describe('The exact MongoDB ID of the category (Required for income/expense)'),
-        categoryName: z.string().optional().describe('The display name of the category (for UI purposes)'),
-        toAccountId: z.string().optional().describe('The exact MongoDB ID of the destination account (Required ONLY for transfers)'),
-        toAccountName: z.string().optional().describe('The display name of the destination account (for UI purposes)'),
-        date: z.string().optional().describe('The date of the transaction in YYYY-MM-DD format. Default is today.'),
+        accountName: z
+          .string()
+          .describe('The display name of the source account (for UI purposes)'),
+        categoryId: z
+          .string()
+          .nullish()
+          .describe(
+            'The exact MongoDB ID of the category (Required for income/expense, null for transfers)'
+          ),
+        categoryName: z
+          .string()
+          .nullish()
+          .describe('The display name of the category (for UI purposes, null for transfers)'),
+        toAccountId: z
+          .string()
+          .nullish()
+          .describe(
+            'The exact MongoDB ID of the destination account (Required ONLY for transfers, null for income/expense)'
+          ),
+        toAccountName: z
+          .string()
+          .nullish()
+          .describe(
+            'The display name of the destination account (for UI purposes, null for income/expense)'
+          ),
+        date: z
+          .string()
+          .nullish()
+          .describe('The date of the transaction in YYYY-MM-DD format. Default is today.'),
       }),
     }
   );
@@ -298,6 +296,6 @@ export function createFinanceTools() {
     createGetCategoriesTool(),
     createGetTransactionsTool(),
     createGetAnalysisTool(),
-    createAddTransactionTool(),
+    createDraftTransactionTool(),
   ];
 }


### PR DESCRIPTION
This PR introduces a new capability to the Pocketly finance chatbot allowing users to draft transactions using natural language (e.g. "I spent 500 on coffee"). It uses a safe "draft and confirm" workflow where the LLM parses the input and a confirmation card is rendered in the chat UI before any database operations occur.

---
*PR created automatically by Jules for task [17974569263942927006](https://jules.google.com/task/17974569263942927006) started by @hasanraiyan*