### PR TITLE
feat(finance): add ask_clarification_question tool and MCQ UI

### DIFF
--- a/src/components/chatbot/MessageList.js
+++ b/src/components/chatbot/MessageList.js
@@ -13,6 +13,107 @@ export default function MessageList({
 }) {
   const isGreenTheme = theme === 'green';
 
+  const formatMcqUserMessage = (content) => {
+    if (!content || typeof content !== 'string') return content;
+
+    // Single-question MCQ answer: [MCQ answer <id>] Selected options: opt_a, opt_b | Other: ...
+    if (content.startsWith('[MCQ answer ')) {
+      const afterTag = content.replace(/^\[MCQ answer [^\]]+\]\s*/u, '');
+
+      const selectedMatch = afterTag.match(/Selected options:\s*([^|]+)/i);
+      const otherMatch = afterTag.match(/\bOther:\s*(.+)$/i);
+
+      const selectedRaw = (selectedMatch?.[1] || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+
+      const prettifyId = (id) => {
+        if (!id) return id;
+        const cleaned = id.replace(/^mcq[-_]/i, '').replace(/[_-]+/g, ' ');
+        return cleaned
+          .split(' ')
+          .filter(Boolean)
+          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+          .join(' ');
+      };
+
+      const prettyOptions = selectedRaw.map(prettifyId);
+      const otherText = otherMatch?.[1]?.trim();
+
+      if (prettyOptions.length === 0 && !otherText) {
+        return content;
+      }
+
+      if (prettyOptions.length > 0 && otherText) {
+        return `You chose: ${prettyOptions.join(', ')}\nOther: ${otherText}`;
+      }
+
+      if (prettyOptions.length > 0) {
+        return `You chose: ${prettyOptions.join(', ')}`;
+      }
+
+      return `You answered: ${otherText}`;
+    }
+
+    // Group MCQ answers: [MCQ group <id>] Q q1: selected: ... || Q q2: selected: ...
+    if (content.startsWith('[MCQ group ')) {
+      const afterTag = content.replace(/^\[MCQ group [^\]]+\]\s*/u, '');
+
+      const parts = afterTag
+        .split('||')
+        .map((part) => part.trim())
+        .filter(Boolean);
+      if (parts.length === 0) return content;
+
+      const lines = parts.map((part) => {
+        // Expect something like: Q qid: selected: a, b | other: text
+        const withoutQ = part.replace(/^Q\s+/i, '').trim();
+        const [qidPart, rest = ''] = withoutQ.split(':').map((x) => x.trim());
+
+        const selectedMatch = rest.match(/selected:\s*([^|]+)/i);
+        const otherMatch = rest.match(/other:\s*(.+)$/i);
+
+        const selectedRaw = (selectedMatch?.[1] || '')
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+
+        const prettifyId = (id) => {
+          if (!id) return id;
+          const cleaned = id.replace(/^mcq[-_]/i, '').replace(/[_-]+/g, ' ');
+          return cleaned
+            .split(' ')
+            .filter(Boolean)
+            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(' ');
+        };
+
+        const prettyOptions = selectedRaw.map(prettifyId);
+        const otherText = otherMatch?.[1]?.trim();
+
+        const label = prettifyId(qidPart || 'Question');
+        const pieces = [];
+        if (prettyOptions.length) {
+          pieces.push(prettyOptions.join(', '));
+        }
+        if (otherText) {
+          pieces.push(`Other: ${otherText}`);
+        }
+
+        if (pieces.length === 0) return null;
+        return `- ${label}: ${pieces.join(' | ')}`;
+      });
+
+      const filteredLines = lines.filter(Boolean);
+      if (!filteredLines.length) return content;
+
+      return `You answered:\n${filteredLines.join('\n')}`;
+    }
+
+    return content;
+  };
+
   return (
     <div className="flex-1 overflow-y-auto overflow-x-hidden p-3 sm:p-5 space-y-3 bg-gradient-to-b from-white/50 to-neutral-50/50 custom-chat-scrollbar">
       {messages.map((message, index) => {
@@ -85,7 +186,7 @@ export default function MessageList({
                   {message.role === 'assistant' ? (
                     <MdContent content={message.content} onLinkClick={handleLinkClick} />
                   ) : (
-                    <MdContent content={message.content} isUser={true} />
+                    <MdContent content={formatMcqUserMessage(message.content)} isUser={true} />
                   )}
                   <p className={`text-[10px] mt-1.5 text-neutral-400`}>
                     {message.timestamp.toLocaleTimeString([], {

--- a/src/components/pocketly-tracker/ChatTab.js
+++ b/src/components/pocketly-tracker/ChatTab.js
@@ -111,6 +111,50 @@ export default function ChatTab() {
       };
       openEditTransaction(preFillData);
     }
+
+    if (action.type === 'mcq_response') {
+      const { questionId, selectionMode, selectedOptionIds = [], otherText } = action;
+
+      const parts = [];
+      if (selectedOptionIds.length > 0) {
+        parts.push(`Selected options: ${selectedOptionIds.join(', ')}`);
+      }
+      if (otherText) {
+        parts.push(`Other: ${otherText}`);
+      }
+
+      if (parts.length === 0) return;
+
+      const prefix = questionId ? `[MCQ answer ${questionId}] ` : '';
+      const summary = `${prefix}${parts.join(' | ')}`;
+
+      sendMessage(summary);
+    }
+
+    if (action.type === 'mcq_group_response') {
+      const { groupId, answers = {} } = action;
+
+      const lines = Object.entries(answers)
+        .map(([qid, answer]) => {
+          const parts = [];
+          if (answer.selectedOptionIds?.length) {
+            parts.push(`selected: ${answer.selectedOptionIds.join(', ')}`);
+          }
+          if (answer.otherText) {
+            parts.push(`other: ${answer.otherText}`);
+          }
+          if (parts.length === 0) return null;
+          return `Q ${qid}: ${parts.join(' | ')}`;
+        })
+        .filter(Boolean);
+
+      if (!lines.length) return;
+
+      const prefix = groupId ? `[MCQ group ${groupId}] ` : '';
+      const summary = `${prefix}${lines.join(' || ')}`;
+
+      sendMessage(summary);
+    }
   };
 
   return (

--- a/src/components/pocketly-tracker/FinanceChatBlockRenderer.js
+++ b/src/components/pocketly-tracker/FinanceChatBlockRenderer.js
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { ArrowLeftRight, Landmark, TrendingDown, TrendingUp } from 'lucide-react';
 import IconRenderer from './IconRenderer';
+import { McqQuestionBlock } from './McqQuestionBlocks';
 
 const currencyFormatter = new Intl.NumberFormat('en-IN', {
   minimumFractionDigits: 0,
@@ -332,6 +333,10 @@ export default function FinanceChatBlockRenderer({ block, onInteract }) {
 
   if (block.kind === 'transaction_confirmation') {
     return <TransactionConfirmationBlock block={block} onInteract={onInteract} />;
+  }
+
+  if (block.kind === 'mcq_question' || block.kind === 'mcq_question_group') {
+    return <McqQuestionBlock block={block} onInteract={onInteract} />;
   }
 
   return null;

--- a/src/components/pocketly-tracker/McqQuestionBlocks.js
+++ b/src/components/pocketly-tracker/McqQuestionBlocks.js
@@ -1,0 +1,236 @@
+'use client';
+
+import { useState } from 'react';
+import BottomSheet from './BottomSheet';
+
+export function McqQuestionBlock({ block, onInteract }) {
+  const data = block.data || {};
+  const isGroup = Array.isArray(data.questions) && data.questions.length > 0;
+  const questions = isGroup ? data.questions : [];
+
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [answers, setAnswers] = useState({});
+  const [submitted, setSubmitted] = useState(false);
+  const [sheetOpen] = useState(true);
+
+  if (submitted) return null;
+
+  const currentQuestion = isGroup ? questions[activeIndex] : null;
+  const currentAnswer = isGroup
+    ? answers[currentQuestion?.id] || { selected: [], otherText: '' }
+    : answers['_single'] || { selected: [], otherText: '' };
+
+  const currentOptions = isGroup ? currentQuestion?.options || [] : data.options || [];
+  const currentAllowFreeText = isGroup
+    ? currentQuestion?.allowFreeText !== false
+    : data.allowFreeText !== false;
+  const isMultiple = isGroup
+    ? currentQuestion?.selectionMode === 'multiple'
+    : data.selectionMode === 'multiple';
+
+  if (!isGroup) {
+    if (!data.question || !Array.isArray(data.options) || data.options.length === 0) {
+      return null;
+    }
+  } else {
+    if (questions.length === 0 || !currentQuestion) return null;
+  }
+
+  const answerKey = isGroup ? currentQuestion.id : '_single';
+
+  const updateCurrentAnswer = (updater) => {
+    setAnswers((prev) => ({
+      ...prev,
+      [answerKey]: updater(prev[answerKey] || { selected: [], otherText: '' }),
+    }));
+  };
+
+  const toggleOption = (optionId) => {
+    updateCurrentAnswer((prev) => {
+      const alreadySelected = prev.selected.includes(optionId);
+      if (isMultiple) {
+        return {
+          ...prev,
+          selected: alreadySelected
+            ? prev.selected.filter((id) => id !== optionId)
+            : [...prev.selected, optionId],
+        };
+      }
+      return {
+        ...prev,
+        selected: alreadySelected ? [] : [optionId],
+      };
+    });
+  };
+
+  const handleOtherTextChange = (e) => {
+    const text = e.target.value;
+    updateCurrentAnswer((prev) => {
+      const next = { ...prev, otherText: text };
+      const hasOther = next.selected.includes('other');
+      const shouldHaveOther = text.trim().length > 0;
+
+      if (shouldHaveOther && !hasOther) {
+        next.selected = isMultiple ? [...next.selected, 'other'] : ['other'];
+      }
+      if (!shouldHaveOther && hasOther) {
+        next.selected = next.selected.filter((id) => id !== 'other');
+      }
+
+      return next;
+    });
+  };
+
+  const handlePrevious = () => {
+    setActiveIndex((idx) => Math.max(0, idx - 1));
+  };
+
+  const handleNext = () => {
+    setActiveIndex((idx) => Math.min(questions.length - 1, idx + 1));
+  };
+
+  const handleSubmitSingle = () => {
+    const answer = answers['_single'];
+    if (!answer) return;
+
+    const selectedOptionIds = answer.selected || [];
+    const otherText = (answer.otherText || '').trim();
+    if (selectedOptionIds.length === 0 && !otherText) return;
+
+    onInteract?.({
+      type: 'mcq_response',
+      questionId: data.id,
+      selectionMode: isMultiple ? 'multiple' : 'single',
+      selectedOptionIds,
+      otherText: otherText || null,
+    });
+
+    setSubmitted(true);
+  };
+
+  const handleSubmitGroup = () => {
+    const normalized = {};
+
+    for (const q of questions) {
+      const answer = answers[q.id];
+      if (!answer) continue;
+
+      const selected = answer.selected || [];
+      const otherText = (answer.otherText || '').trim();
+      if (selected.length === 0 && !otherText) continue;
+
+      normalized[q.id] = {
+        selectedOptionIds: selected,
+        otherText: otherText || null,
+        selectionMode: q.selectionMode === 'multiple' ? 'multiple' : 'single',
+      };
+    }
+
+    if (Object.keys(normalized).length === 0) return;
+
+    onInteract?.({
+      type: 'mcq_group_response',
+      groupId: data.id,
+      answers: normalized,
+    });
+
+    setSubmitted(true);
+  };
+
+  const isLast = activeIndex === questions.length - 1;
+  const questionText = isGroup ? currentQuestion.question : data.question;
+
+  const renderCard = () => (
+    <div className="rounded-2xl border border-neutral-200/70 bg-[#f8f8f4] p-3">
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs font-semibold text-neutral-800 flex-1 mr-2">{questionText}</p>
+        {isGroup && (
+          <p className="text-[10px] font-medium text-neutral-500 shrink-0">
+            {activeIndex + 1} / {questions.length}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        {currentOptions.map((opt) => {
+          const isOther = opt.id === 'other';
+          const checked = currentAnswer.selected.includes(opt.id);
+
+          return (
+            <div
+              key={opt.id}
+              className="rounded-xl border border-neutral-200 bg-white px-3 py-2 flex items-start gap-2"
+            >
+              <input
+                type={isMultiple ? 'checkbox' : 'radio'}
+                className="mt-1 h-3.5 w-3.5 cursor-pointer"
+                checked={checked}
+                onChange={() => toggleOption(opt.id)}
+              />
+              <div className="flex-1 min-w-0">
+                <p className="text-xs font-semibold text-neutral-900 truncate">{opt.label}</p>
+                {opt.description && (
+                  <p className="mt-0.5 text-[11px] text-neutral-500 line-clamp-2">
+                    {opt.description}
+                  </p>
+                )}
+                {isOther && currentAllowFreeText && (
+                  <textarea
+                    rows={2}
+                    className="mt-1 w-full resize-none rounded-lg border border-neutral-200 px-2 py-1 text-[11px] text-neutral-800 focus:outline-none focus:ring-1 focus:ring-[#1f644e]"
+                    placeholder="Add a short note..."
+                    value={currentAnswer.otherText}
+                    onChange={handleOtherTextChange}
+                  />
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-3 flex items-center justify-between">
+        {isGroup ? (
+          <>
+            <button
+              type="button"
+              onClick={handlePrevious}
+              disabled={activeIndex === 0}
+              className="rounded-full border border-neutral-200 bg-white px-3 py-2 text-xs font-semibold text-neutral-700 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer hover:bg-neutral-50"
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              onClick={isLast ? handleSubmitGroup : handleNext}
+              className="rounded-full bg-[#1e3a34] px-3 py-2 text-xs font-semibold text-white cursor-pointer hover:bg-[#152924]"
+            >
+              {isLast ? 'Submit answers' : 'Next'}
+            </button>
+          </>
+        ) : (
+          <div className="ml-auto">
+            <button
+              type="button"
+              onClick={handleSubmitSingle}
+              className="rounded-full bg-[#1e3a34] px-3 py-2 text-xs font-semibold text-white cursor-pointer hover:bg-[#152924]"
+            >
+              Submit
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      <div className="hidden sm:block">{renderCard()}</div>
+      <div className="sm:hidden">
+        <BottomSheet open={sheetOpen && !submitted} onClose={() => {}} mobileOnly>
+          {renderCard()}
+        </BottomSheet>
+      </div>
+    </>
+  );
+}

--- a/src/lib/agents/ai/finance-assistant-agent.js
+++ b/src/lib/agents/ai/finance-assistant-agent.js
@@ -90,6 +90,16 @@ function parseToolOutput(output) {
     return output;
   }
 
+  // ask_user_mcq payloads (single question or group) are plain objects
+  // with question/options or questions[]. Pass them through so the UI
+  // builder can construct the right blocks.
+  if (
+    (typeof output.question === 'string' && Array.isArray(output.options)) ||
+    Array.isArray(output.questions)
+  ) {
+    return output;
+  }
+
   return null;
 }
 
@@ -100,6 +110,7 @@ function getToolLabel(toolName) {
     get_accounts: 'Checking accounts',
     get_categories: 'Reviewing categories',
     draft_transaction: 'Drafting transaction',
+    ask_clarification_question: 'Asking you a question',
   };
 
   return labels[toolName] || `Using ${toolName}`;
@@ -107,6 +118,7 @@ function getToolLabel(toolName) {
 
 function shouldRenderGui(toolName, toolArgs = {}) {
   if (toolName === 'draft_transaction') return true;
+  if (toolName === 'ask_clarification_question') return true;
   if (toolArgs?.presentation === 'card') return true;
   return toolArgs?.isGui === true;
 }
@@ -205,6 +217,69 @@ function buildUiBlocks(toolName, output, toolArgs = {}) {
     ];
   }
 
+  if (toolName === 'ask_clarification_question') {
+    // Group of questions flow
+    if (Array.isArray(parsed.questions) && parsed.questions.length > 0) {
+      const groupId = parsed.id || parsed.groupId || `mcq-group-${Date.now()}`;
+
+      const questions = parsed.questions.map((q) => {
+        const allowFreeText = q.allowFreeText !== false;
+        const options = (q.options || []).map((opt) => ({
+          id: String(opt.id),
+          label: String(opt.label),
+          description: opt.description ?? undefined,
+        }));
+
+        return {
+          id: String(q.id),
+          question: q.question,
+          selectionMode: q.selectionMode === 'multiple' ? 'multiple' : 'single',
+          allowFreeText,
+          options,
+        };
+      });
+
+      return [
+        {
+          kind: 'mcq_question_group',
+          title: 'A few quick questions',
+          action: null,
+          data: {
+            id: groupId,
+            questions,
+          },
+        },
+      ];
+    }
+
+    // Single question
+    if (parsed.question && Array.isArray(parsed.options)) {
+      const allowFreeText = parsed.allowFreeText !== false;
+      const options = (parsed.options || []).map((opt) => ({
+        id: String(opt.id),
+        label: String(opt.label),
+        description: opt.description ?? undefined,
+      }));
+
+      return [
+        {
+          kind: 'mcq_question',
+          title: 'Quick question',
+          action: null,
+          data: {
+            id: parsed.id || parsed.questionId || `mcq-${Date.now()}`,
+            question: parsed.question,
+            selectionMode: parsed.selectionMode === 'multiple' ? 'multiple' : 'single',
+            allowFreeText,
+            options,
+          },
+        },
+      ];
+    }
+
+    return [];
+  }
+
   return [];
 }
 
@@ -298,7 +373,21 @@ When the user is trying to record, add, log, save, or draft a transaction, follo
 - For transfers, set toAccountResolvedViaTool=true only after resolving toAccountId with get_accounts.
 - If multiple accounts or categories could match, ask which one the user means.
 - If no matching account or category exists, say so and ask the user to choose from available options.
-- Once the draft is complete, briefly summarize it in natural language and then let the confirmation UI appear.`,
+- Once the draft is complete, briefly summarize it in natural language and then let the confirmation UI appear.
+
+You also have a clarification tool called ask_clarification_question:
+- Use it when you need the user to choose from a small, clear set of options (2-8) instead of typing a free-text answer.
+- Good use cases: disambiguating which account or category they mean, choosing between 2-4 interpretations of their request, asking for simple preferences (timeframes, goals, budget style), or confirming next steps.
+- Always include an "Other" option so the user can override the list.
+- Use single-select by default; use multi-select only if it is natural for the question (for example, "Which goals do you want to focus on?" where multiple goals are fine).
+- Keep flows short: either a single question or a mini-sequence of 2-4 questions.
+
+How clarification answers appear in chat:
+- The app will convert MCQ answers into normal-looking user messages such as:
+  - [MCQ answer spending-timeframe] Selected options: last_30_days
+  - [MCQ answer transfer-target] Selected options: emergency_fund | Other: Move to gold ETF instead
+  - [MCQ group onboarding-goals] Q saving-style: selected: aggressive || Q tracking-preference: selected: weekly, alerts
+- Treat these as reliable structured answers you requested. Do not ask the same clarification again unless the user explicitly says they want to change it.`,
     });
 
     const messages = [
@@ -384,6 +473,14 @@ When the user is trying to record, add, log, save, or draft a transaction, follo
 
         if (toolCallId) {
           activeToolCalls.delete(toolCallId);
+        }
+
+        // When we ask a clarification question via the MCQ UI, treat that as the
+        // end of this assistant turn. The user must now answer the card before
+        // we continue, so we stop the LangGraph stream here to avoid generating
+        // extra explanatory text that we will ignore on the client anyway.
+        if (toolName === 'ask_clarification_question') {
+          return;
         }
       }
     }

--- a/src/lib/agents/utils/finance-tools.js
+++ b/src/lib/agents/utils/finance-tools.js
@@ -435,6 +435,156 @@ export function createDraftTransactionTool() {
   );
 }
 
+export function createAskClarificationQuestionTool() {
+  const mcqOptionSchema = z.object({
+    id: z.string().describe('Stable machine-readable option id (e.g. "yes", "no", "weekly").'),
+    label: z.string().describe('Human-readable label for the option.'),
+    description: z.string().optional().describe('Optional short helper text for the option.'),
+  });
+
+  const singleQuestionSchema = z.object({
+    question: z
+      .string()
+      .describe('The question to show the user, phrased in simple, direct language.'),
+    options: z
+      .array(mcqOptionSchema)
+      .min(2)
+      .max(8)
+      .describe('2-8 clear options that cover the most likely answers.'),
+    selectionMode: z
+      .enum(['single', 'multiple'])
+      .optional()
+      .describe(
+        'Use "single" for one choice, "multiple" when several choices make sense. Defaults to "single".'
+      ),
+    questionId: z
+      .string()
+      .optional()
+      .describe('Stable identifier for this question so you can recognize the answer later.'),
+    allowFreeText: z
+      .boolean()
+      .optional()
+      .describe(
+        'Whether the "Other" option should allow a free-text explanation. Defaults to true.'
+      ),
+  });
+
+  const groupQuestionSchema = z.object({
+    id: z
+      .string()
+      .describe(
+        'Stable identifier for this question within the group. Used in the answer payload.'
+      ),
+    question: z
+      .string()
+      .describe('The question to show the user, phrased in simple, direct language.'),
+    options: z
+      .array(mcqOptionSchema)
+      .min(2)
+      .max(8)
+      .describe('2-8 clear options that cover the most likely answers.'),
+    selectionMode: z
+      .enum(['single', 'multiple'])
+      .optional()
+      .describe(
+        'Use "single" for one choice, "multiple" when several choices make sense. Defaults to "single".'
+      ),
+    allowFreeText: z
+      .boolean()
+      .optional()
+      .describe(
+        'Whether the "Other" option should allow a free-text explanation. Defaults to true.'
+      ),
+  });
+
+  const groupSchema = z.object({
+    groupId: z
+      .string()
+      .optional()
+      .describe(
+        'Stable identifier for this group of questions so you can recognize the grouped answer later.'
+      ),
+    questions: z
+      .array(groupQuestionSchema)
+      .min(1)
+      .max(6)
+      .describe('An ordered list of 1-6 short questions to ask as a mini-flow.'),
+  });
+
+  function normalizeOptions(rawOptions, allowFreeText) {
+    const options = (rawOptions || []).map((opt) => ({
+      id: String(opt.id),
+      label: String(opt.label),
+      description: opt.description ?? undefined,
+    }));
+
+    const hasOther = options.some((opt) => {
+      if (opt.id === 'other') return true;
+      const label = (opt.label || '').trim().toLowerCase();
+      return label === 'other';
+    });
+
+    if (!hasOther) {
+      options.push({
+        id: 'other',
+        label: 'Other',
+        description:
+          allowFreeText === false ? undefined : 'Share your own preference in a short sentence.',
+      });
+    }
+
+    return options;
+  }
+
+  function normalizeSelectionMode(mode) {
+    return mode === 'multiple' ? 'multiple' : 'single';
+  }
+
+  return tool(
+    async (input) => {
+      // The schema ensures we either have a single-question payload
+      // or a group payload with a questions array.
+
+      if (Array.isArray(input.questions) && input.questions.length > 0) {
+        const allowGroupFreeTextDefault = true;
+
+        const groupId = input.groupId || `mcq-group-${Date.now()}`;
+        const questions = input.questions.map((q) => {
+          const allowFreeText = q.allowFreeText !== false && allowGroupFreeTextDefault;
+          return {
+            id: q.id,
+            question: q.question,
+            selectionMode: normalizeSelectionMode(q.selectionMode),
+            allowFreeText,
+            options: normalizeOptions(q.options, allowFreeText),
+          };
+        });
+
+        return {
+          id: groupId,
+          questions,
+        };
+      }
+
+      const allowFreeText = input.allowFreeText !== false;
+
+      return {
+        id: input.questionId || `mcq-${Date.now()}`,
+        question: input.question,
+        selectionMode: normalizeSelectionMode(input.selectionMode),
+        allowFreeText,
+        options: normalizeOptions(input.options, allowFreeText),
+      };
+    },
+    {
+      name: 'ask_clarification_question',
+      description:
+        'Ask the user a focused clarification question as a multiple-choice prompt (or a very short group of prompts). Use this when the answer is best captured as a small set of options (with an automatic "Other" choice), like preferences, disambiguation, or next-step choices. For a single clarification, pass question + options. For a short flow, pass questions[]. The UI will handle navigation, Previous/Next, and Submit.',
+      schema: z.union([singleQuestionSchema, groupSchema]),
+    }
+  );
+}
+
 export function createFinanceTools() {
   return [
     createGetAccountsTool(),
@@ -442,5 +592,6 @@ export function createFinanceTools() {
     createGetTransactionsTool(),
     createGetAnalysisTool(),
     createDraftTransactionTool(),
+    createAskClarificationQuestionTool(),
   ];
 }

--- a/src/lib/finance-chat/messageState.js
+++ b/src/lib/finance-chat/messageState.js
@@ -109,7 +109,20 @@ export function restoreMessagesFromStorage(rawMessages) {
 
 export function applyCloudStreamEventToMessages(messages, assistantMsgId, event) {
   if (event.type === 'content') {
-    const nextContent = messages.find((message) => message.id === assistantMsgId)?.content || '';
+    const target = messages.find((message) => message.id === assistantMsgId);
+    if (!target) return messages;
+
+    const hasBlockingUi = (target.uiBlocks || []).some(
+      (block) => block.kind === 'mcq_question' || block.kind === 'mcq_question_group'
+    );
+
+    // If we already showed an MCQ clarification UI for this assistant turn,
+    // ignore any further text tokens so the user only sees the question card.
+    if (hasBlockingUi) {
+      return messages;
+    }
+
+    const nextContent = target.content || '';
     const fullContent = nextContent + event.message;
     return messages.map((message) =>
       message.id === assistantMsgId ? { ...message, content: fullContent } : message
@@ -176,8 +189,15 @@ export function applyCloudStreamEventToMessages(messages, assistantMsgId, event)
         }
       }
 
+      const hasBlockingUi = (event.uiBlocks || []).some(
+        (block) => block.kind === 'mcq_question' || block.kind === 'mcq_question_group'
+      );
+
       return {
         ...message,
+        // If this tool_end introduced an MCQ clarification UI, clear any
+        // accumulated assistant text so the user just sees the question card.
+        content: hasBlockingUi ? '' : message.content,
         steps: finalizedSteps,
         uiBlocks: nextBlocks,
         guiRequested: message.guiRequested || event.guiRequested || false,


### PR DESCRIPTION
- Add unified `ask_clarification_question` tool (single question or group) via `createAskClarificationQuestionTool()` in finance-tools.js.
- Extend `finance-assistant-agent.js` to emit `mcq_question` / `mcq_question_group` uiBlocks and stop the LangGraph stream after the tool fires (avoids wasted tokens).
- Add `McqQuestionBlock` component in `McqQuestionBlocks.js` that handles both single and group MCQs; uses BottomSheet on mobile, inline card on desktop/tablet.
- Wire MCQ interactions in `ChatTab.js` to send structured answer messages back into chat (`mcq_response` / `mcq_group_response`).
- Format user MCQ answer bubbles in `MessageList.js` to be human-readable instead of raw `[MCQ answer ...]` tags.
- Guard in `messageState.js` to suppress text after an MCQ block is shown for the same assistant turn.