### PR TITLE
Fix: Add cache invalidation to landing page admin updates

### DIFF
--- a/src/app/api/about/route.js
+++ b/src/app/api/about/route.js
@@ -5,6 +5,7 @@
  */
 
 import { NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
 import dbConnect from '@/lib/dbConnect';
 import AboutSection from '@/models/AboutSection';
 import { getServerSession } from 'next-auth';
@@ -215,6 +216,8 @@ export async function PUT(request) {
       });
       await aboutData.save();
     }
+
+    revalidatePath('/');
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/admin/sections/[type]/route.js
+++ b/src/app/api/admin/sections/[type]/route.js
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
 import dbConnect from '@/lib/dbConnect';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
@@ -70,6 +71,8 @@ export async function PUT(request, { params }) {
     } else {
       data = await Model.create(body);
     }
+
+    revalidatePath('/');
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/hero/route.js
+++ b/src/app/api/hero/route.js
@@ -5,6 +5,7 @@
  */
 
 import { NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
 import dbConnect from '@/lib/dbConnect';
 import HeroSection from '@/models/HeroSection';
 import { getServerSession } from 'next-auth';
@@ -207,6 +208,8 @@ export async function PUT(request) {
       });
       await heroData.save();
     }
+
+    revalidatePath('/');
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/stats/route.js
+++ b/src/app/api/stats/route.js
@@ -5,6 +5,7 @@
  */
 
 import { NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
 import dbConnect from '@/lib/dbConnect';
 import StatsSection from '@/models/StatsSection';
 import { getServerSession } from 'next-auth';
@@ -208,6 +209,8 @@ export async function PUT(request) {
       });
       await statsData.save();
     }
+
+    revalidatePath('/');
 
     return NextResponse.json({
       success: true,


### PR DESCRIPTION
Fixed an issue where changes to the landing page sections in the admin panel (like Hero, About, Stats, etc.) took a long time to appear or required a redeploy. This was due to Next.js aggressively caching the landing page and not being instructed to invalidate the cache when API mutations occurred. This PR adds `revalidatePath('/')` to the relevant PUT operations.

---
*PR created automatically by Jules for task [6388263521104884327](https://jules.google.com/task/6388263521104884327) started by @hasanraiyan*