### PR TITLE
Fix snaplinks analytics and slug lookup logic

### DIFF
--- a/src/app/api/admin/short-links/analytics/route.js
+++ b/src/app/api/admin/short-links/analytics/route.js
@@ -12,9 +12,10 @@ export async function GET(request) {
 
     const { searchParams } = new URL(request.url);
     const slug = searchParams.get('slug'); // Optional: filter by specific link
+    const id = searchParams.get('id'); // Optional: filter by specific link id
     const days = parseInt(searchParams.get('days') || '30', 10);
 
-    const stats = await getAnalyticsOverview({ slug, days });
+    const stats = await getAnalyticsOverview({ slug, id, days });
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/admin/short-links/route.js
+++ b/src/app/api/admin/short-links/route.js
@@ -45,6 +45,10 @@ export async function POST(request) {
       const messages = error.errors.map((err) => err.message).join(', ');
       return NextResponse.json({ error: `Validation Error: ${messages}` }, { status: 400 });
     }
+    if (error.name === 'ValidationError') {
+      const messages = Object.values(error.errors).map(err => err.message).join(', ');
+      return NextResponse.json({ error: `Validation Error: ${messages}` }, { status: 400 });
+    }
     if (error.message === 'Slug already exists') {
        return NextResponse.json({ error: 'Slug already exists' }, { status: 409 });
     }
@@ -74,6 +78,10 @@ export async function PUT(request) {
     console.error('Error updating short link:', error);
     if (error.name === 'ZodError') {
       const messages = error.errors.map((err) => err.message).join(', ');
+      return NextResponse.json({ error: `Validation Error: ${messages}` }, { status: 400 });
+    }
+    if (error.name === 'ValidationError') {
+      const messages = Object.values(error.errors).map(err => err.message).join(', ');
       return NextResponse.json({ error: `Validation Error: ${messages}` }, { status: 400 });
     }
     if (error.message === 'New slug already exists') {

--- a/src/lib/apps/snaplinks/service/service.js
+++ b/src/lib/apps/snaplinks/service/service.js
@@ -70,11 +70,15 @@ export async function createLink(payload) {
 export async function getLink(slugOrId) {
   await ensureDb();
   let link;
-  if (isValidObjectId(slugOrId)) {
+
+  // Prefer slug lookup first to support 24-hex alphanumeric slugs
+  link = await ShortLink.findOne({ slug: slugOrId.trim().toLowerCase() }).lean();
+
+  // Fallback to ObjectId lookup if not found by slug
+  if (!link && isValidObjectId(slugOrId)) {
     link = await ShortLink.findById(slugOrId).lean();
-  } else {
-    link = await ShortLink.findOne({ slug: slugOrId.trim().toLowerCase() }).lean();
   }
+
   return link;
 }
 
@@ -189,7 +193,7 @@ export async function getDashboardStats() {
   };
 }
 
-export async function getAnalyticsOverview({ slug, days = 30 } = {}) {
+export async function getAnalyticsOverview({ slug, id, days = 30 } = {}) {
   await ensureDb();
 
   const endDate = new Date();
@@ -199,8 +203,21 @@ export async function getAnalyticsOverview({ slug, days = 30 } = {}) {
   const matchCriteria = {
     timestamp: { $gte: startDate, $lte: endDate },
   };
-  if (slug) {
-    matchCriteria.slug = slug.toLowerCase();
+
+  let linkDetails = null;
+  const identifier = id || slug;
+  if (identifier) {
+    linkDetails = await getLink(identifier);
+    if (!linkDetails) {
+      throw new Error('Short link not found');
+    }
+    matchCriteria.shortLink = linkDetails._id;
+  } else {
+    linkDetails = {
+      totalLinksCreated: await ShortLink.countDocuments({
+        createdAt: { $gte: startDate, $lte: endDate },
+      }),
+    };
   }
 
   const [
@@ -292,17 +309,6 @@ export async function getAnalyticsOverview({ slug, days = 30 } = {}) {
       { $project: { _id: 0, country: '$_id', count: 1 } },
     ]),
   ]);
-
-  let linkDetails = null;
-  if (slug) {
-    linkDetails = await ShortLink.findOne({ slug: slug.toLowerCase() }).lean();
-  } else {
-    linkDetails = {
-      totalLinksCreated: await ShortLink.countDocuments({
-        createdAt: { $gte: startDate, $lte: endDate },
-      }),
-    };
-  }
 
   return {
     summary: {

--- a/src/lib/mcp/snaplinksServer.js
+++ b/src/lib/mcp/snaplinksServer.js
@@ -173,15 +173,16 @@ export function createSnaplinksMcpServer() {
       description:
         'Return analytics for a short link (top countries, referrers, and clicks over time).',
       inputSchema: {
-        slug: z.string().describe('Slug to fetch stats for'),
+        slug: z.string().optional().describe('Slug to fetch stats for (provide slug or id)'),
+        id: z.string().optional().describe('ID to fetch stats for (provide slug or id)'),
         days: z.number().int().min(1).max(365).optional().describe('Days window (default 30)'),
       },
     },
-    async ({ slug, days }) => {
-      if (!slug) return { content: [{ type: 'text', text: 'slug is required' }], isError: true };
+    async ({ slug, id, days }) => {
+      if (!slug && !id) return { content: [{ type: 'text', text: 'slug or id is required' }], isError: true };
 
       try {
-        const stats = await getAnalyticsOverview({ slug, days });
+        const stats = await getAnalyticsOverview({ slug, id, days });
         if (!stats.linkDetails) {
           return { content: [{ type: 'text', text: 'Link not found' }], isError: true };
         }


### PR DESCRIPTION
Resolves issues where analytics were improperly linked to mutable slugs instead of the permanent shortLink IDs, allows creation of valid 24-hex alphanumeric slugs, and properly surfaces Mongoose ValidationError feedback in the short-links API.

---
*PR created automatically by Jules for task [16507897571152844220](https://jules.google.com/task/16507897571152844220) started by @hasanraiyan*