### PR TITLE
feat: Refactor internal apps to use shared AppLayout

### DIFF
--- a/src/app/apps/memoscribe/page.js
+++ b/src/app/apps/memoscribe/page.js
@@ -6,7 +6,7 @@ import { FileText, MessageCircle, Settings as SettingsIcon } from 'lucide-react'
 import NotesTab from '@/components/memoscribe/NotesTab';
 import ChatTab from '@/components/memoscribe/ChatTab';
 import SettingsTab from '@/components/memoscribe/SettingsTab';
-import AppHeader from '@/components/memoscribe/AppHeader';
+import AppLayout from '@/components/layout/AppLayout';
 
 const tabs = [
   { id: 'notes', label: 'Clips', icon: FileText },
@@ -18,63 +18,18 @@ function MemoscribeContent() {
   const { activeTab, setActiveTab } = useMemoscribe();
 
   return (
-    <div className="min-h-screen bg-[#fcfbf5] font-[family-name:var(--font-sans)] text-[#1e3a34] flex">
-      {/* Desktop Sidebar */}
-      <aside className="hidden lg:flex flex-col w-64 bg-white border-r border-[#e5e3d8] fixed inset-y-0 left-0 z-30">
-        <div className="p-6">
-          <h1 className="font-[family-name:var(--font-logo)] text-2xl text-[#1f644e]">
-            Memo Scribe
-          </h1>
-        </div>
-        <nav className="flex-1 px-4 space-y-2">
-          {tabs.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={`w-full cursor-pointer flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-bold transition-all ${
-                activeTab === tab.id
-                  ? 'bg-[#1f644e] text-white'
-                  : 'text-[#7c8e88] hover:bg-[#f0f5f2] hover:text-[#1e3a34]'
-              }`}
-            >
-              <tab.icon className="w-5 h-5" strokeWidth={activeTab === tab.id ? 2 : 1.5} />
-              {tab.label}
-            </button>
-          ))}
-        </nav>
-      </aside>
-
-      {/* Main Content */}
-      <div className="flex min-w-0 flex-1 flex-col lg:ml-64 min-h-screen overflow-x-hidden pb-20 lg:pb-0 pt-14 lg:pt-0">
-        <AppHeader />
-
-        {/* Main Area */}
-        <main className="min-w-0 flex-1 w-full overflow-x-hidden p-4 lg:p-6 max-w-6xl mx-auto">
-          {activeTab === 'notes' && <NotesTab />}
-          {activeTab === 'chat' && <ChatTab />}
-          {activeTab === 'settings' && <SettingsTab />}
-        </main>
+    <AppLayout
+      appName="Memo Scribe"
+      tabs={tabs}
+      activeTab={activeTab}
+      setActiveTab={setActiveTab}
+    >
+      <div className="p-4 lg:p-6 max-w-6xl mx-auto">
+        {activeTab === 'notes' && <NotesTab />}
+        {activeTab === 'chat' && <ChatTab />}
+        {activeTab === 'settings' && <SettingsTab />}
       </div>
-
-      {/* Mobile Bottom Nav */}
-      <nav className="lg:hidden fixed bottom-0 left-0 right-0 bg-[#fcfbf5] border-t border-[#e5e3d8] z-30 flex">
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
-            className={`flex-1 flex flex-col items-center py-2 cursor-pointer ${
-              activeTab === tab.id ? 'text-[#1f644e]' : 'text-[#7c8e88]'
-            }`}
-          >
-            <tab.icon
-              className="w-[22px] h-[22px] mb-0.5"
-              strokeWidth={activeTab === tab.id ? 2 : 1.5}
-            />
-            <span className="text-[10px] font-bold">{tab.label}</span>
-          </button>
-        ))}
-      </nav>
-    </div>
+    </AppLayout>
   );
 }
 

--- a/src/app/apps/pocketly/page.js
+++ b/src/app/apps/pocketly/page.js
@@ -31,6 +31,7 @@ import {
   MessageCircle,
 } from 'lucide-react';
 import { useCallback, useState } from 'react';
+import AppLayout from '@/components/layout/AppLayout';
 
 const AccountsTab = dynamic(() => import('@/components/pocketly-tracker/AccountsTab'), {
   loading: () => <AccountsSkeleton />,
@@ -65,72 +66,6 @@ const tabs = [
   { id: 'chat', label: 'Chat', icon: MessageCircle },
   { id: 'settings', label: 'Settings', icon: Settings },
 ];
-
-function PocketlyNavigation({ tabs, activeTab, setActiveTab }) {
-  return (
-    <>
-      {/* Desktop Sidebar */}
-      <aside className="hidden lg:flex flex-col w-64 bg-white border-r border-[#e5e3d8] fixed inset-y-0 left-0 z-30">
-        <div className="p-6 border-b border-[#e5e3d8]">
-          <div className="flex items-center gap-2">
-            <Image
-              src="/images/apps/pocketly.png"
-              alt="Pocketly app logo"
-              width={28}
-              height={28}
-              className="rounded-xl shadow-sm"
-              priority
-            />
-            <h1 className="font-[family-name:var(--font-logo)] text-2xl text-black ">Pocketly</h1>
-          </div>
-        </div>
-        <nav className="flex-1 py-4 px-3 space-y-1 overflow-y-auto">
-          {tabs.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={`w-full cursor-pointer flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-bold transition-all ${
-                activeTab === tab.id
-                  ? 'bg-[#1f644e] text-white'
-                  : 'text-[#7c8e88] hover:bg-[#f0f5f2] hover:text-[#1e3a34]'
-              }`}
-            >
-              <tab.icon className="w-5 h-5" strokeWidth={activeTab === tab.id ? 2 : 1.5} />
-              {tab.label}
-            </button>
-          ))}
-        </nav>
-        <div className="p-4 border-t border-[#e5e3d8]">
-          <p className="text-[10px] text-[#7c8e88] text-center">Powered by Pocketly</p>
-        </div>
-      </aside>
-
-      {/* Mobile Bottom Nav (without Settings tab) */}
-      <nav
-        className="lg:hidden fixed bottom-0 left-0 right-0 bg-[#fcfbf5] border-t border-[#e5e3d8] z-30 flex"
-        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
-      >
-        {tabs
-          .filter((tab) => tab.id !== 'settings')
-          .map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={`flex-1 flex flex-col items-center py-2 ${
-                activeTab === tab.id ? 'text-[#1f644e]' : 'text-[#7c8e88]'
-              }`}
-            >
-              <tab.icon
-                className="w-[22px] h-[22px] mb-0.5"
-                strokeWidth={activeTab === tab.id ? 2 : 1.5}
-              />
-              <span className="text-[10px] font-bold">{tab.label}</span>
-            </button>
-          ))}
-      </nav>
-    </>
-  );
-}
 
 function FinanceContent() {
   const { data: session, status } = useSession();
@@ -258,79 +193,57 @@ function FinanceContent() {
   };
 
   return (
-    <div className="min-h-screen bg-[#fcfbf5] font-[family-name:var(--font-sans)] text-[#1e3a34] flex">
-      <PocketlyNavigation tabs={tabs} activeTab={activeTab} setActiveTab={setActiveTab} />
-
-      {/* Main Content Area */}
-      <div className="flex min-w-0 flex-1 flex-col lg:ml-64 min-h-screen overflow-x-hidden pb-16 lg:pb-0 pt-14 lg:pt-0">
-        {/* Header */}
-        <header className="lg:sticky lg:top-0 fixed top-0 left-0 right-0 z-50 bg-[#fcfbf5] border-b border-[#e5e3d8]">
-          <div className="w-full px-4 lg:px-6 py-3 flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="flex items-center gap-2 lg:hidden">
-                <Image
-                  src="/images/apps/pocketly.png"
-                  alt="Pocketly app logo"
-                  width={24}
-                  height={24}
-                  className="rounded-lg shadow-sm"
-                  priority
-                />
-                <h1 className="font-[family-name:var(--font-logo)] text-xl lg:text-2xl text-black">
-                  Pocketly
-                </h1>
-              </div>
-              <h1 className="hidden lg:block text-lg font-bold text-[#1e3a34]">
-                {tabTitles[activeTab]}
-              </h1>
-            </div>
-            <div className="flex items-center gap-3">
-              {activeTab === 'chat' && (
-                <button
-                  onClick={clearChat}
-                  className="cursor-pointer flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100 transition-colors"
-                >
-                  <Plus className="w-3.5 h-3.5" />
-                  New Chat
-                </button>
-              )}
-              {isSyncing && (
-                <div className="flex items-center gap-1.5 text-xs text-[#7c8e88]">
-                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                  <span>Syncing...</span>
-                </div>
-              )}
-              {/* Mobile Settings shortcut: move settings off bottom nav */}
-              <button
-                type="button"
-                onClick={() => setActiveTab('settings')}
-                className="lg:hidden p-1.5 rounded-full text-[#7c8e88] hover:text-[#1e3a34] hover:bg-neutral-100 transition-colors"
-                aria-label="Open settings"
-              >
-                <Settings className="w-5 h-5" />
-              </button>
-            </div>
-          </div>
-        </header>
-
-        {/* Content */}
-        <main className="min-w-0 flex-1 w-full overflow-x-hidden">
-          {shouldShowBootstrapSkeleton ? (
-            activeBootstrapSkeleton
-          ) : shouldHoldBootstrapFrame ? (
-            <div className="min-h-[60vh]" />
-          ) : (
-            renderTab()
+    <AppLayout
+      appName="Pocketly"
+      appLogo="/images/apps/pocketly.png"
+      tabs={tabs}
+      activeTab={activeTab}
+      setActiveTab={setActiveTab}
+      tabTitles={tabTitles}
+      hideSettingsFromMobileNav={true}
+      headerActions={
+        <>
+          {activeTab === 'chat' && (
+            <button
+              onClick={clearChat}
+              className="cursor-pointer flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100 transition-colors"
+            >
+              <Plus className="w-3.5 h-3.5" />
+              New Chat
+            </button>
           )}
-        </main>
-      </div>
-
-      {/* FAB / Edit Modal */}
-      {(accounts.length > 0 && activeTab !== 'settings' && activeTab !== 'chat') ||
-      editTransactionData ? (
-        <AddTransactionModal />
-      ) : null}
-    </div>
+          {isSyncing && (
+            <div className="flex items-center gap-1.5 text-xs text-[#7c8e88]">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              <span>Syncing...</span>
+            </div>
+          )}
+          {/* Mobile Settings shortcut: move settings off bottom nav */}
+          <button
+            type="button"
+            onClick={() => setActiveTab('settings')}
+            className="lg:hidden p-1.5 rounded-full text-[#7c8e88] hover:text-[#1e3a34] hover:bg-neutral-100 transition-colors"
+            aria-label="Open settings"
+          >
+            <Settings className="w-5 h-5" />
+          </button>
+        </>
+      }
+      fab={
+        (accounts.length > 0 && activeTab !== 'settings' && activeTab !== 'chat') ||
+        editTransactionData ? (
+          <AddTransactionModal />
+        ) : null
+      }
+    >
+      {shouldShowBootstrapSkeleton ? (
+        activeBootstrapSkeleton
+      ) : shouldHoldBootstrapFrame ? (
+        <div className="min-h-[60vh]" />
+      ) : (
+        renderTab()
+      )}
+    </AppLayout>
   );
 }
 

--- a/src/app/apps/snaplinks/page.js
+++ b/src/app/apps/snaplinks/page.js
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { LayoutDashboard, Link2, BarChart3, Settings, Menu } from 'lucide-react';
 import SessionProvider from '@/components/SessionProvider';
+import AppLayout from '@/components/layout/AppLayout';
 
 const DashboardTab = dynamic(() => import('@/components/snaplinks/DashboardTab'), {
   loading: () => <div className="p-6">Loading Dashboard...</div>,
@@ -70,76 +71,18 @@ function SnapLinksContent() {
   };
 
   return (
-    <div className="min-h-screen bg-[#fcfbf5] font-[family-name:var(--font-sans)] text-[#1e3a34] flex">
-      {/* Desktop Sidebar */}
-      <aside className="hidden lg:flex flex-col w-64 bg-white border-r border-[#e5e3d8] fixed inset-y-0 left-0 z-30">
-        <div className="p-6 border-b border-[#e5e3d8]">
-          <h1 className="font-[family-name:var(--font-logo)] text-2xl text-[#1f644e] flex items-center gap-2">
-            <img src="/images/apps/Snaplinks.png" alt="SnapLinks" className="h-8 w-auto" />
-            SnapLinks
-          </h1>
-        </div>
-        <nav className="flex-1 py-4 px-3 space-y-1">
-          {tabs.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={`w-full cursor-pointer flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-bold transition-all ${
-                activeTab === tab.id
-                  ? 'bg-[#1f644e] text-white'
-                  : 'text-[#7c8e88] hover:bg-[#f0f5f2] hover:text-[#1e3a34]'
-              }`}
-            >
-              <tab.icon className="w-5 h-5" strokeWidth={activeTab === tab.id ? 2 : 1.5} />
-              {tab.label}
-            </button>
-          ))}
-        </nav>
-      </aside>
-
-      {/* Main Content Area */}
-      <div className="flex min-w-0 flex-1 flex-col lg:ml-64 min-h-screen overflow-x-hidden">
-        {/* Header */}
-        <header className="bg-[#fcfbf5] fixed top-0 left-0 lg:left-64 right-0 z-40 border-b border-[#e5e3d8]/50">
-          <div className="w-full px-4 lg:px-6 py-3 flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <h1 className="font-[family-name:var(--font-logo)] text-xl lg:text-2xl text-[#1f644e] lg:hidden flex items-center gap-2">
-                <img src="/images/apps/Snaplinks.png" alt="SnapLinks" className="h-6 w-auto" />
-                SnapLinks
-              </h1>
-              <h1 className="hidden lg:block text-lg font-bold text-[#1e3a34]">
-                {tabTitles[activeTab]}
-              </h1>
-            </div>
-          </div>
-        </header>
-
-        {/* Content */}
-        <main className="min-w-0 flex-1 w-full overflow-x-hidden pt-12 pb-20 lg:pb-0">
-          {renderTab()}
-        </main>
+    <AppLayout
+      appName="SnapLinks"
+      appLogo="/images/apps/Snaplinks.png"
+      tabs={tabs}
+      activeTab={activeTab}
+      setActiveTab={setActiveTab}
+      tabTitles={tabTitles}
+    >
+      <div className="pt-2 lg:pt-6 pb-20 lg:pb-0">
+        {renderTab()}
       </div>
-
-      {/* Mobile Bottom Nav */}
-      <nav className="lg:hidden fixed bottom-0 left-0 right-0 bg-[#fcfbf5] border-t border-[#e5e3d8] z-30 flex pb-safe">
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
-            className={`flex-1 flex flex-col items-center justify-center py-3 min-h-[60px] ${
-              activeTab === tab.id ? 'text-[#1f644e]' : 'text-[#4a5c56] hover:text-[#1e3a34]'
-            }`}
-          >
-            <tab.icon className="w-6 h-6 mb-1" strokeWidth={activeTab === tab.id ? 2.5 : 2} />
-            <span
-              className={`text-[10px] ${activeTab === tab.id ? 'font-extrabold' : 'font-bold'}`}
-            >
-              {tab.label}
-            </span>
-          </button>
-        ))}
-      </nav>
-    </div>
+    </AppLayout>
   );
 }
 

--- a/src/app/apps/taskly/page.js
+++ b/src/app/apps/taskly/page.js
@@ -8,6 +8,7 @@ import SessionProvider from '@/components/SessionProvider';
 import { TasklyProvider, useTaskly } from '@/context/TasklyContext';
 import { TasklyChatProvider, useTasklyChat } from '@/context/TasklyChatContext';
 import { TasklyTabSkeleton, ChatSkeleton } from '@/components/taskly/TasklySkeletons';
+import AppLayout from '@/components/layout/AppLayout';
 import {
   CheckSquare,
   FolderKanban,
@@ -130,116 +131,35 @@ function TasklyContent() {
   };
 
   return (
-    <div className="min-h-screen bg-[#fcfbf5] font-[family-name:var(--font-sans)] text-[#1e3a34] flex">
-      <aside className="hidden lg:flex flex-col w-64 bg-white border-r border-[#e5e3d8] fixed inset-y-0 left-0 z-30">
-        <div className="p-6 border-b border-[#e5e3d8]">
-          <h1 className="font-[family-name:var(--font-logo)] text-2xl text-[#1f644e]">Taskly</h1>
-        </div>
-        <nav className="flex-1 py-4 px-3 space-y-1">
-          {tabs.map((tab) => (
+    <AppLayout
+      appName="Taskly"
+      tabs={tabs}
+      activeTab={activeTab}
+      setActiveTab={setActiveTab}
+      tabTitles={tabTitles}
+      useHamburgerMenu={false} // Uses standard bottom nav
+      headerActions={
+        <>
+          {activeTab === 'chat' && (
             <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={`w-full cursor-pointer flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-bold transition-all ${
-                activeTab === tab.id
-                  ? 'bg-[#1f644e] text-white'
-                  : 'text-[#7c8e88] hover:bg-[#f0f5f2] hover:text-[#1e3a34]'
-              }`}
+              onClick={clearChat}
+              className="cursor-pointer flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100 transition-colors"
             >
-              <tab.icon className="w-5 h-5" strokeWidth={activeTab === tab.id ? 2 : 1.5} />
-              {tab.label}
+              <Plus className="w-3.5 h-3.5" />
+              New Chat
             </button>
-          ))}
-        </nav>
-      </aside>
-
-      <div className="flex min-w-0 flex-1 flex-col lg:ml-64 min-h-screen overflow-x-hidden">
-        <header className="bg-[#fcfbf5] sticky top-0 z-20 border-b border-[#e5e3d8]">
-          <div className="w-full px-4 lg:px-6 py-3 flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <button className="lg:hidden p-1" onClick={() => setSidebarOpen(true)}>
-                <Menu className="w-5 h-5 text-[#1e3a34]" />
-              </button>
-              <h1 className="font-[family-name:var(--font-logo)] text-xl text-[#1f644e] lg:hidden">
-                Taskly
-              </h1>
-              <h1 className="hidden lg:block text-lg font-bold text-[#1e3a34]">
-                {tabTitles[activeTab]}
-              </h1>
+          )}
+          {isBootstrapLoading && (
+            <div className="flex items-center gap-1.5 text-xs text-[#7c8e88]">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              <span>Syncing...</span>
             </div>
-            <div className="flex items-center gap-3">
-              {activeTab === 'chat' && (
-                <button
-                  onClick={clearChat}
-                  className="cursor-pointer flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100 transition-colors"
-                >
-                  <Plus className="w-3.5 h-3.5" />
-                  New Chat
-                </button>
-              )}
-              {isBootstrapLoading && (
-                <div className="flex items-center gap-1.5 text-xs text-[#7c8e88]">
-                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                  <span>Syncing...</span>
-                </div>
-              )}
-            </div>
-          </div>
-        </header>
-
-        <main className="min-w-0 flex-1 w-full overflow-x-hidden">{renderTab()}</main>
-      </div>
-
-      {sidebarOpen && (
-        <div className="fixed inset-0 z-40 lg:hidden">
-          <div className="absolute inset-0 bg-black/50" onClick={() => setSidebarOpen(false)} />
-          <aside className="absolute inset-y-0 left-0 w-64 bg-white shadow-xl animate-in slide-in-from-left duration-300">
-            <div className="p-6 border-b border-[#e5e3d8]">
-              <h1 className="font-[family-name:var(--font-logo)] text-2xl text-[#1f644e]">
-                Taskly
-              </h1>
-            </div>
-            <nav className="py-4 px-3 space-y-1">
-              {tabs.map((tab) => (
-                <button
-                  key={tab.id}
-                  onClick={() => {
-                    setActiveTab(tab.id);
-                    setSidebarOpen(false);
-                  }}
-                  className={`w-full cursor-pointer flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-bold transition-all ${
-                    activeTab === tab.id
-                      ? 'bg-[#1f644e] text-white'
-                      : 'text-[#7c8e88] hover:bg-[#f0f5f2]'
-                  }`}
-                >
-                  <tab.icon className="w-5 h-5" />
-                  {tab.label}
-                </button>
-              ))}
-            </nav>
-          </aside>
-        </div>
-      )}
-
-      <nav className="lg:hidden fixed bottom-0 left-0 right-0 bg-[#fcfbf5] border-t border-[#e5e3d8] z-30 flex">
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
-            className={`flex-1 flex flex-col items-center py-2 ${
-              activeTab === tab.id ? 'text-[#1f644e]' : 'text-[#7c8e88]'
-            }`}
-          >
-            <tab.icon
-              className="w-[22px] h-[22px] mb-0.5"
-              strokeWidth={activeTab === tab.id ? 2 : 1.5}
-            />
-            <span className="text-[10px] font-bold">{tab.label}</span>
-          </button>
-        ))}
-      </nav>
-    </div>
+          )}
+        </>
+      }
+    >
+      {renderTab()}
+    </AppLayout>
   );
 }
 

--- a/src/components/layout/AppLayout.js
+++ b/src/components/layout/AppLayout.js
@@ -1,0 +1,192 @@
+import React from 'react';
+import Image from 'next/image';
+import { Menu } from 'lucide-react';
+
+/**
+ * AppLayout Component
+ * A standardized layout shell for internal mini-apps.
+ *
+ * @param {Object} props
+ * @param {string} props.appName - The name of the application (e.g., "Pocketly", "Taskly").
+ * @param {string|React.ReactNode} [props.appLogo] - Optional path to the app logo image or a custom logo React node.
+ * @param {Array<{id: string, label: string, icon: React.ElementType}>} props.tabs - Array of tab objects.
+ * @param {string} props.activeTab - The currently active tab ID.
+ * @param {function} props.setActiveTab - Function to change the active tab.
+ * @param {React.ReactNode} props.children - The main content area for the active tab.
+ * @param {React.ReactNode} [props.headerActions] - Optional extra components to render in the right side of the header.
+ * @param {React.ReactNode} [props.fab] - Optional Floating Action Button component.
+ * @param {boolean} [props.hideSettingsFromMobileNav] - Whether to hide the tab with id 'settings' from the mobile bottom nav.
+ * @param {boolean} [props.useHamburgerMenu] - If true, displays a hamburger menu for mobile instead of bottom nav. Note: Avoid for mobile layouts if all primary navigation tabs are already accessible via a bottom navigation bar.
+ * @param {Object} [props.tabTitles] - Optional map of tab IDs to their display titles in the header. If omitted, uses the label from `tabs`.
+ */
+export default function AppLayout({
+  appName,
+  appLogo,
+  tabs,
+  activeTab,
+  setActiveTab,
+  children,
+  headerActions = null,
+  fab = null,
+  hideSettingsFromMobileNav = false,
+  useHamburgerMenu = false,
+  tabTitles = null,
+}) {
+  const [sidebarOpen, setSidebarOpen] = React.useState(false);
+
+  const getTabTitle = () => {
+    if (tabTitles && tabTitles[activeTab]) {
+      return tabTitles[activeTab];
+    }
+    const currentTab = tabs.find((t) => t.id === activeTab);
+    return currentTab ? currentTab.label : appName;
+  };
+
+  const renderLogo = (isMobileHeader = false) => {
+    if (React.isValidElement(appLogo)) {
+      return appLogo;
+    }
+    if (typeof appLogo === 'string') {
+      return (
+        <div className={`flex items-center gap-2 ${isMobileHeader ? 'lg:hidden' : ''}`}>
+          <Image
+            src={appLogo}
+            alt={`${appName} logo`}
+            width={isMobileHeader ? 24 : 28}
+            height={isMobileHeader ? 24 : 28}
+            className={isMobileHeader ? "rounded-lg shadow-sm" : "rounded-xl shadow-sm h-8 w-auto"}
+            priority
+          />
+          <h1 className={`font-[family-name:var(--font-logo)] text-${isMobileHeader ? 'xl lg:text-2xl' : '2xl'} ${appName === 'SnapLinks' ? 'text-[#1f644e]' : 'text-black'}`}>
+            {appName}
+          </h1>
+        </div>
+      );
+    }
+    // Fallback if no logo provided
+    return (
+      <h1 className={`font-[family-name:var(--font-logo)] text-${isMobileHeader ? 'xl lg:text-2xl' : '2xl'} text-[#1f644e] ${isMobileHeader ? 'lg:hidden' : ''}`}>
+        {appName}
+      </h1>
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-[#fcfbf5] font-[family-name:var(--font-sans)] text-[#1e3a34] flex">
+      {/* Desktop Sidebar */}
+      <aside className="hidden lg:flex flex-col w-64 bg-white border-r border-[#e5e3d8] fixed inset-y-0 left-0 z-30">
+        <div className="p-6 border-b border-[#e5e3d8]">
+          <div className="flex items-center gap-2">
+             {renderLogo()}
+          </div>
+        </div>
+        <nav className="flex-1 py-4 px-3 space-y-1 overflow-y-auto">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`w-full cursor-pointer flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-bold transition-all ${
+                activeTab === tab.id
+                  ? 'bg-[#1f644e] text-white'
+                  : 'text-[#7c8e88] hover:bg-[#f0f5f2] hover:text-[#1e3a34]'
+              }`}
+            >
+              <tab.icon className="w-5 h-5" strokeWidth={activeTab === tab.id ? 2 : 1.5} />
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+      </aside>
+
+      {/* Main Content Area */}
+      <div className="flex min-w-0 flex-1 flex-col lg:ml-64 min-h-screen overflow-x-hidden pb-16 lg:pb-0 pt-14 lg:pt-0">
+        {/* Header */}
+        <header className="lg:sticky lg:top-0 fixed top-0 left-0 right-0 z-20 bg-[#fcfbf5] border-b border-[#e5e3d8]">
+          <div className="w-full px-4 lg:px-6 py-3 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              {useHamburgerMenu && (
+                <button className="lg:hidden p-1" onClick={() => setSidebarOpen(true)}>
+                  <Menu className="w-5 h-5 text-[#1e3a34]" />
+                </button>
+              )}
+              {renderLogo(true)}
+              <h1 className="hidden lg:block text-lg font-bold text-[#1e3a34]">
+                {getTabTitle()}
+              </h1>
+            </div>
+            <div className="flex items-center gap-3">
+              {headerActions}
+            </div>
+          </div>
+        </header>
+
+        {/* Content */}
+        <main className="min-w-0 flex-1 w-full overflow-x-hidden">
+          {children}
+        </main>
+      </div>
+
+      {/* Mobile Hamburger Menu Drawer */}
+      {useHamburgerMenu && sidebarOpen && (
+        <div className="fixed inset-0 z-40 lg:hidden">
+          <div className="absolute inset-0 bg-black/50" onClick={() => setSidebarOpen(false)} />
+          <aside className="absolute inset-y-0 left-0 w-64 bg-white shadow-xl animate-in slide-in-from-left duration-300">
+            <div className="p-6 border-b border-[#e5e3d8]">
+               {renderLogo()}
+            </div>
+            <nav className="py-4 px-3 space-y-1 overflow-y-auto">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => {
+                    setActiveTab(tab.id);
+                    setSidebarOpen(false);
+                  }}
+                  className={`w-full cursor-pointer flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-bold transition-all ${
+                    activeTab === tab.id
+                      ? 'bg-[#1f644e] text-white'
+                      : 'text-[#7c8e88] hover:bg-[#f0f5f2] hover:text-[#1e3a34]'
+                  }`}
+                >
+                  <tab.icon className="w-5 h-5" strokeWidth={activeTab === tab.id ? 2 : 1.5} />
+                  {tab.label}
+                </button>
+              ))}
+            </nav>
+          </aside>
+        </div>
+      )}
+
+      {/* Mobile Bottom Nav */}
+      {!useHamburgerMenu && (
+        <nav
+          className="lg:hidden fixed bottom-0 left-0 right-0 bg-[#fcfbf5] border-t border-[#e5e3d8] z-30 flex"
+          style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+        >
+          {tabs
+            .filter((tab) => !hideSettingsFromMobileNav || tab.id !== 'settings')
+            .map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`flex-1 flex flex-col items-center justify-center py-2 min-h-[60px] ${
+                  activeTab === tab.id ? 'text-[#1f644e]' : 'text-[#7c8e88] hover:text-[#1e3a34]'
+                }`}
+              >
+                <tab.icon
+                  className="w-[22px] h-[22px] mb-0.5"
+                  strokeWidth={activeTab === tab.id ? 2 : 1.5}
+                />
+                <span className={`text-[10px] ${activeTab === tab.id ? 'font-extrabold' : 'font-bold'}`}>
+                  {tab.label}
+                </span>
+              </button>
+            ))}
+        </nav>
+      )}
+
+      {/* Floating Action Button */}
+      {fab}
+    </div>
+  );
+}

--- a/src/components/layout/README.md
+++ b/src/components/layout/README.md
@@ -1,0 +1,69 @@
+# AppLayout
+
+`AppLayout` is a shared layout shell component designed to standardize the structure of internal mini-apps like Pocketly, Taskly, SnapLinks, and Memo Scribe. It provides a consistent responsive layout with a desktop sidebar, a mobile bottom navigation bar (or optional hamburger menu), a unified header, and support for Floating Action Buttons (FABs).
+
+## Usage
+
+```jsx
+import AppLayout from '@/components/layout/AppLayout';
+import { Home, Settings } from 'lucide-react';
+
+const tabs = [
+  { id: 'home', label: 'Home', icon: Home },
+  { id: 'settings', label: 'Settings', icon: Settings },
+];
+
+function MyAppContent() {
+  const [activeTab, setActiveTab] = useState('home');
+
+  const renderContent = () => {
+    switch (activeTab) {
+       case 'home': return <HomeTab />;
+       case 'settings': return <SettingsTab />;
+       default: return <HomeTab />;
+    }
+  }
+
+  return (
+    <AppLayout
+      appName="MyApp"
+      appLogo="/images/apps/myapp.png"
+      tabs={tabs}
+      activeTab={activeTab}
+      setActiveTab={setActiveTab}
+      headerActions={
+        <button>New Item</button>
+      }
+      fab={<MyFabComponent />}
+    >
+      {renderContent()}
+    </AppLayout>
+  );
+}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `appName` | `string` | **Required** | The name of the application (e.g., "Pocketly"). Used in the logo section and fallback header title. |
+| `appLogo` | `string` \| `ReactNode` | `null` | Path to the app logo image (string) or a custom React node. |
+| `tabs` | `Array` | **Required** | Array of tab objects. Each object should have `{id: string, label: string, icon: LucideIcon}`. |
+| `activeTab` | `string` | **Required** | The ID of the currently active tab. |
+| `setActiveTab` | `function` | **Required** | Function to update the active tab state when a nav item is clicked. |
+| `children` | `ReactNode` | **Required** | The main content area of the app (the active tab's view). |
+| `headerActions` | `ReactNode` | `null` | Optional components to render in the top right corner of the header (e.g., Syncing status, "New Chat" button). |
+| `fab` | `ReactNode` | `null` | Optional Floating Action Button component. Make sure this component uses `fixed` positioning. |
+| `hideSettingsFromMobileNav` | `boolean` | `false` | If true, the tab with `id === 'settings'` will not be rendered in the mobile bottom navigation bar. Useful when settings is accessed via a header shortcut. |
+| `useHamburgerMenu` | `boolean` | `false` | If true, renders a hamburger menu for mobile instead of a bottom navigation bar. Note: The memory guidelines suggest avoiding this if all primary navigation tabs can be fit in a bottom nav bar. |
+| `tabTitles` | `Object` | `null` | An optional map of tab IDs to their display titles in the header. If not provided, it falls back to the tab's `label` property or the `appName`. Example: `{ chat: 'Pocketly Chat' }`. |
+
+## Migration Notes
+
+When migrating an existing app (like Pocketly or Taskly) to `AppLayout`:
+
+1.  Remove the app's custom `Aside`, `Header`, and Mobile Nav components.
+2.  Pass the app's `tabs` array to `AppLayout`.
+3.  Extract any special header buttons (like the `Settings` shortcut in Pocketly, or the `New Chat` button) into a `<React.Fragment>` and pass it to the `headerActions` prop.
+4.  Pass the FAB (if any) to the `fab` prop.
+5.  If the app hides the "Settings" tab from the mobile bottom nav (like Pocketly does), set `hideSettingsFromMobileNav={true}`.


### PR DESCRIPTION
Created a new `AppLayout` component to standardize the layout shell across the various Next.js mini-apps (Pocketly, SnapLinks, Memoscribe, Taskly).

This deduplicates the sidebar, mobile bottom navigation, and top header code across these apps, making it easier to create new apps with consistent branding and structure in the future. The `Vaultly` app was left as-is because it relies on a unique breadcrumb and state-driven top navigation bar.

---
*PR created automatically by Jules for task [17606627219722959582](https://jules.google.com/task/17606627219722959582) started by @hasanraiyan*