### PR TITLE
feat(pocketly): integrate categories and budgets into unified planning tab

### DIFF
--- a/patch_toptabs.sh
+++ b/patch_toptabs.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-sed -i 's/{option.label && <span className="hidden sm:inline truncate">{option.label}<\/span>}/{option.label \&\& <span className={`truncate ${showLabelOnMobile ? "" : "hidden sm:inline"}`}>{option.label}<\/span>}/' src/components/ui/TopTabs.js

--- a/patch_toptabs.sh
+++ b/patch_toptabs.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sed -i 's/{option.label && <span className="hidden sm:inline truncate">{option.label}<\/span>}/{option.label \&\& <span className={`truncate ${showLabelOnMobile ? "" : "hidden sm:inline"}`}>{option.label}<\/span>}/' src/components/ui/TopTabs.js

--- a/src/app/apps/pocketly/page.js
+++ b/src/app/apps/pocketly/page.js
@@ -29,8 +29,7 @@ import { useCallback, useState } from 'react';
 import AppLayout from '@/components/layout/AppLayout';
 
 const AccountsTab = dynamic(() => import('@/components/pocketly-tracker/AccountsTab'));
-const CategoriesTab = dynamic(() => import('@/components/pocketly-tracker/CategoriesTab'));
-const BudgetsTab = dynamic(() => import('@/components/pocketly-tracker/BudgetsTab'));
+const PlanningTab = dynamic(() => import('@/components/pocketly-tracker/PlanningTab'));
 const AnalysisTab = dynamic(() => import('@/components/pocketly-tracker/AnalysisTab'));
 const ChatTab = dynamic(() => import('@/components/pocketly-tracker/ChatTab'));
 const FinanceSettingsTab = dynamic(
@@ -41,8 +40,7 @@ const tabs = [
   { id: 'records', label: 'Records', icon: Receipt },
   { id: 'analysis', label: 'Analysis', icon: BarChart3 },
   { id: 'accounts', label: 'Accounts', icon: Wallet },
-  { id: 'categories', label: 'Categories', icon: Tag },
-  { id: 'budgets', label: 'Budgets', icon: Target },
+  { id: 'planning', label: 'Planning', icon: Target },
   { id: 'chat', label: 'Chat', icon: MessageCircle },
   { id: 'settings', label: 'Settings', icon: Settings },
 ];
@@ -126,8 +124,7 @@ function FinanceContent() {
       'records',
       'analysis',
       'accounts',
-      'categories',
-      'budgets',
+      'planning',
       'chat',
       'settings',
     ];
@@ -147,10 +144,8 @@ function FinanceContent() {
               onAddModalClose={handleAddModalClose}
             />
           );
-        case 'categories':
-          return <CategoriesTab />;
-        case 'budgets':
-          return <BudgetsTab />;
+        case 'planning':
+          return <PlanningTab />;
         case 'chat':
           return <ChatTab />;
         case 'settings':
@@ -167,8 +162,7 @@ function FinanceContent() {
     records: 'Records',
     analysis: 'Analysis',
     accounts: 'Accounts',
-    categories: 'Categories',
-    budgets: 'Budgets',
+    planning: 'Planning',
     chat: 'Chat',
     settings: 'Settings',
   };

--- a/src/app/apps/pocketly/page.js
+++ b/src/app/apps/pocketly/page.js
@@ -120,14 +120,7 @@ function FinanceContent() {
       );
     }
 
-    const skeletonTabs = [
-      'records',
-      'analysis',
-      'accounts',
-      'planning',
-      'chat',
-      'settings',
-    ];
+    const skeletonTabs = ['records', 'analysis', 'accounts', 'planning', 'chat', 'settings'];
     const shouldShowSkeleton =
       skeletonTabs.includes(activeTab) && isBootstrapLoading && showDelayedBootstrapSkeleton;
 

--- a/src/components/pocketly-tracker/BudgetsTab.js
+++ b/src/components/pocketly-tracker/BudgetsTab.js
@@ -118,7 +118,7 @@ export default function BudgetsTab() {
   };
 
   return (
-    <div className="mb-6">
+    <div className="w-full">
       <div className="w-full px-4 lg:px-6">
         <div className="w-full max-w-6xl mx-auto">
           <div className="mb-6 flex items-center justify-between">

--- a/src/components/pocketly-tracker/BudgetsTab.js
+++ b/src/components/pocketly-tracker/BudgetsTab.js
@@ -118,7 +118,7 @@ export default function BudgetsTab() {
   };
 
   return (
-    <div className="mb-6 bg-[#fcfbf5] pt-4 pb-24 sm:pt-6 sm:pb-8">
+    <div className="mb-6">
       <div className="w-full px-4 lg:px-6">
         <div className="w-full max-w-6xl mx-auto">
           <div className="mb-6 flex items-center justify-between">

--- a/src/components/pocketly-tracker/CategoriesTab.js
+++ b/src/components/pocketly-tracker/CategoriesTab.js
@@ -191,7 +191,7 @@ export default function CategoriesTab() {
   );
 
   return (
-    <div className="mb-6">
+    <div className="w-full">
       <div className="w-full px-4 lg:px-6">
         <div className="w-full max-w-6xl mx-auto">
           {/* Summary */}

--- a/src/components/pocketly-tracker/CategoriesTab.js
+++ b/src/components/pocketly-tracker/CategoriesTab.js
@@ -191,7 +191,7 @@ export default function CategoriesTab() {
   );
 
   return (
-    <div className="mb-6 pb-4 pt-6">
+    <div className="mb-6">
       <div className="w-full px-4 lg:px-6">
         <div className="w-full max-w-6xl mx-auto">
           {/* Summary */}

--- a/src/components/pocketly-tracker/PlanningTab.js
+++ b/src/components/pocketly-tracker/PlanningTab.js
@@ -23,6 +23,7 @@ export default function PlanningTab() {
             options={viewOptions}
             activeId={activeView}
             onChange={setActiveView}
+            showLabelOnMobile={true}
           />
         </div>
       </div>

--- a/src/components/pocketly-tracker/PlanningTab.js
+++ b/src/components/pocketly-tracker/PlanningTab.js
@@ -1,0 +1,36 @@
+'use client';
+
+import { useState } from 'react';
+import { Tag, Target } from 'lucide-react';
+import TopTabs from '@/components/ui/TopTabs';
+import CategoriesTab from './CategoriesTab';
+import BudgetsTab from './BudgetsTab';
+
+const viewOptions = [
+  { id: 'categories', label: 'Categories', icon: Tag },
+  { id: 'budgets', label: 'Budgets', icon: Target },
+];
+
+export default function PlanningTab() {
+  const [activeView, setActiveView] = useState('categories');
+
+  return (
+    <div className="w-full pb-24 sm:pb-8">
+      {/* Top Navigation Tabs */}
+      <div className="w-full bg-[#fcfbf5] sticky top-0 z-10 pt-4 pb-3 px-4 lg:px-6">
+        <div className="w-full max-w-6xl mx-auto flex justify-center">
+          <TopTabs
+            options={viewOptions}
+            activeId={activeView}
+            onChange={setActiveView}
+          />
+        </div>
+      </div>
+
+      {/* Content Area */}
+      <div className="w-full pt-4">
+        {activeView === 'categories' ? <CategoriesTab /> : <BudgetsTab />}
+      </div>
+    </div>
+  );
+}

--- a/src/components/pocketly-tracker/PlanningTab.js
+++ b/src/components/pocketly-tracker/PlanningTab.js
@@ -15,9 +15,9 @@ export default function PlanningTab() {
   const [activeView, setActiveView] = useState('categories');
 
   return (
-    <div className="w-full pb-24 sm:pb-8">
+    <div className="w-full pb-28 sm:pb-12">
       {/* Top Navigation Tabs */}
-      <div className="w-full bg-[#fcfbf5] sticky top-14 lg:top-[61px] z-10 pt-4 pb-3 px-4 lg:px-6">
+      <div className="w-full bg-[#fcfbf5] sticky top-14 lg:top-[61px] z-10 pb-4 pt-2 px-4 lg:px-6">
         <div className="w-full max-w-6xl mx-auto flex justify-center">
           <TopTabs
             options={viewOptions}
@@ -29,7 +29,7 @@ export default function PlanningTab() {
       </div>
 
       {/* Content Area */}
-      <div className="w-full pt-4">
+      <div className="w-full">
         {activeView === 'categories' ? <CategoriesTab /> : <BudgetsTab />}
       </div>
     </div>

--- a/src/components/pocketly-tracker/PlanningTab.js
+++ b/src/components/pocketly-tracker/PlanningTab.js
@@ -17,7 +17,7 @@ export default function PlanningTab() {
   return (
     <div className="w-full pb-24 sm:pb-8">
       {/* Top Navigation Tabs */}
-      <div className="w-full bg-[#fcfbf5] sticky top-0 z-10 pt-4 pb-3 px-4 lg:px-6">
+      <div className="w-full bg-[#fcfbf5] sticky top-14 lg:top-[61px] z-10 pt-4 pb-3 px-4 lg:px-6">
         <div className="w-full max-w-6xl mx-auto flex justify-center">
           <TopTabs
             options={viewOptions}

--- a/src/components/ui/TopTabs.js
+++ b/src/components/ui/TopTabs.js
@@ -3,7 +3,7 @@
 import React, { useId } from 'react';
 import { motion } from 'framer-motion';
 
-export default function TopTabs({ options = [], activeId, onChange = () => {}, theme = 'green' }) {
+export default function TopTabs({ options = [], activeId, onChange = () => {}, theme = 'green', showLabelOnMobile = false }) {
   const safeOptions = Array.isArray(options) ? options : [];
 
   // Generates a unique ID so if you have multiple Tab groups on the same page,
@@ -80,7 +80,7 @@ export default function TopTabs({ options = [], activeId, onChange = () => {}, t
             {/* Tab Content (Icon + Label) */}
             <span className="relative z-10 flex items-center gap-2">
               {Icon && <Icon className="h-4 w-4 shrink-0" />}
-              {option.label && <span className="hidden sm:inline truncate">{option.label}</span>}
+              {option.label && <span className={`truncate ${showLabelOnMobile ? "" : "hidden sm:inline"}`}>{option.label}</span>}
             </span>
           </button>
         );

--- a/src/components/ui/TopTabs.js
+++ b/src/components/ui/TopTabs.js
@@ -3,7 +3,13 @@
 import React, { useId } from 'react';
 import { motion } from 'framer-motion';
 
-export default function TopTabs({ options = [], activeId, onChange = () => {}, theme = 'green', showLabelOnMobile = false }) {
+export default function TopTabs({
+  options = [],
+  activeId,
+  onChange = () => {},
+  theme = 'green',
+  showLabelOnMobile = false,
+}) {
   const safeOptions = Array.isArray(options) ? options : [];
 
   // Generates a unique ID so if you have multiple Tab groups on the same page,
@@ -80,7 +86,11 @@ export default function TopTabs({ options = [], activeId, onChange = () => {}, t
             {/* Tab Content (Icon + Label) */}
             <span className="relative z-10 flex items-center gap-2">
               {Icon && <Icon className="h-4 w-4 shrink-0" />}
-              {option.label && <span className={`truncate ${showLabelOnMobile ? "" : "hidden sm:inline"}`}>{option.label}</span>}
+              {option.label && (
+                <span className={`truncate ${showLabelOnMobile ? '' : 'hidden sm:inline'}`}>
+                  {option.label}
+                </span>
+              )}
             </span>
           </button>
         );


### PR DESCRIPTION
# Pocketly App - Integrated Planning Tab

This PR introduces the new `PlanningTab` component in the Pocketly App which serves as a unified entry point for managing both Categories and Budgets.

### Changes
*   **Added `PlanningTab.js`**: Uses `TopTabs` to switch dynamically between `CategoriesTab` and `BudgetsTab` sub-views.
*   **Updated `apps/pocketly/page.js`**:
    *   Removed independent `CategoriesTab` and `BudgetsTab` navigation entries.
    *   Added a unified `PlanningTab` identified by the `Target` icon.
    *   Cleaned up associated loading skeletons and rendering logic.
*   **Refactored `CategoriesTab` & `BudgetsTab`**: Stripped excess margins and padding so they fit correctly when rendered as child components of the new `PlanningTab`.

Visual verifications via playwright confirmed UI updates were implemented successfully without regressions.

---
*PR created automatically by Jules for task [2157336690885082741](https://jules.google.com/task/2157336690885082741) started by @hasanraiyan*