### PR TITLE
fix(coursify-mcp): Complete gap fix — session continuity, missing reads, design flaws

### DIFF
--- a/src/lib/coursify/db-ops.js
+++ b/src/lib/coursify/db-ops.js
@@ -24,38 +24,55 @@ function triggerThumbnail(course) {
 
 // ─── Courses ──────────────────────────────────────────────────────────────────
 
-export async function dbListCourses({ status } = {}) {
+export async function dbListCourses({ status, limit = 20, offset = 0 } = {}) {
   await dbConnect();
   const query = { deletedAt: null };
   if (status && status !== 'all') query.status = status;
 
-  const courses = await CoursifyCourse.find(query).sort({ updatedAt: -1 }).lean();
+  const courses = await CoursifyCourse.find(query)
+    .sort({ updatedAt: -1 })
+    .skip(offset)
+    .limit(limit)
+    .lean();
+
   const courseIds = courses.map((c) => c._id);
 
   const sections = await CoursifySection.find({ courseId: { $in: courseIds }, deletedAt: null })
-    .select('courseId')
+    .select('courseId status')
     .lean();
 
-  const countMap = {};
+  const progressMap = {};
   for (const s of sections) {
-    const id = s.courseId.toString();
-    countMap[id] = (countMap[id] || 0) + 1;
+    const cid = s.courseId.toString();
+    if (!progressMap[cid]) progressMap[cid] = { total: 0, complete: 0 };
+    progressMap[cid].total++;
+    if (s.status === 'complete') progressMap[cid].complete++;
   }
 
-  return courses.map((c) =>
-    normalizeCourse({ ...c, sectionCount: countMap[c._id.toString()] || 0 })
-  );
+  return courses.map((c) => {
+    const progress = progressMap[c._id.toString()] || { total: 0, complete: 0 };
+    return normalizeCourse({
+      ...c,
+      sectionCount: progress.total,
+      sectionsTotal: progress.total,
+      sectionsComplete: progress.complete,
+    });
+  });
 }
 
-export async function dbGetCourse({ id }) {
+export async function dbGetCourse({ id, includeSectionContent = false }) {
   await dbConnect();
   const course = await CoursifyCourse.findOne({ _id: id, deletedAt: null }).lean();
   if (!course) throw new Error('Course not found.');
 
+  const sectionSelect = includeSectionContent
+    ? 'moduleId title content sectionType quiz summary status order learningGoals estimatedDuration resources'
+    : 'moduleId title summary status order learningGoals estimatedDuration resources';
+
   const [modules, sections] = await Promise.all([
     CoursifyModule.find({ courseId: id, deletedAt: null }).sort({ order: 1 }).lean(),
     CoursifySection.find({ courseId: id, deletedAt: null })
-      .select('moduleId title summary status order learningGoals estimatedDuration resources')
+      .select(sectionSelect)
       .sort({ order: 1 })
       .lean(),
   ]);
@@ -64,15 +81,12 @@ export async function dbGetCourse({ id }) {
   const uncategorized = [];
   for (const s of sections) {
     const mid = s.moduleId?.toString();
-    const meta = {
-      id: s._id.toString(),
-      title: s.title,
-      summary: s.summary || '',
-      status: s.status || 'draft',
-      order: s.order ?? 0,
-      learningGoals: s.learningGoals || [],
-      estimatedDuration: s.estimatedDuration || '',
-    };
+    const meta = normalizeSection(s);
+    if (!includeSectionContent) {
+      delete meta.content;
+      delete meta.quiz;
+    }
+
     if (mid) {
       if (!sectionsByModule[mid]) sectionsByModule[mid] = [];
       sectionsByModule[mid].push(meta);
@@ -86,10 +100,37 @@ export async function dbGetCourse({ id }) {
     sections: sectionsByModule[m._id.toString()] || [],
   }));
 
+  const sectionsComplete = sections.filter((s) => s.status === 'complete').length;
+
   return {
-    course: normalizeCourse({ ...course, sectionCount: sections.length }),
+    course: normalizeCourse({
+      ...course,
+      sectionCount: sections.length,
+      sectionsTotal: sections.length,
+      sectionsComplete,
+    }),
     modules: modulesWithSections,
     uncategorizedSections: uncategorized,
+  };
+}
+
+export async function dbGetCourseWorkspace({ id }) {
+  // Full workspace loader: metadata, planning, research, all modules + sections with content
+  const { course, modules, uncategorizedSections } = await dbGetCourse({
+    id,
+    includeSectionContent: true,
+  });
+
+  return {
+    course,
+    modules,
+    uncategorizedSections,
+    researchNotes: course.researchNotes,
+    progressSummary: {
+      sectionsTotal: course.sectionsTotal,
+      sectionsComplete: course.sectionsComplete,
+      authoringStatus: course.authoringStatus,
+    },
   };
 }
 
@@ -219,6 +260,22 @@ export async function dbCreateModule({ courseId, title, summary, learningGoals, 
   });
   await CoursifyCourse.updateOne({ _id: courseId, deletedAt: null }, { $inc: { syncVersion: 1 } });
   return { module: normalizeModule(module.toObject()) };
+}
+
+export async function dbGetModule({ id }) {
+  await dbConnect();
+  const module = await CoursifyModule.findOne({ _id: id, deletedAt: null }).lean();
+  if (!module) throw new Error('Module not found.');
+
+  const sections = await CoursifySection.find({ moduleId: id, deletedAt: null })
+    .select('title summary status order learningGoals estimatedDuration resources')
+    .sort({ order: 1 })
+    .lean();
+
+  return {
+    module: normalizeModule({ ...module, sectionCount: sections.length }),
+    sections: sections.map(normalizeSection),
+  };
 }
 
 export async function dbUpdateModule({ id, title, summary, learningGoals, order, status }) {
@@ -351,11 +408,55 @@ export async function dbUpdateSection({
     { new: true, strict: false }
   ).lean();
   if (!section) throw new Error('Section not found.');
-  await CoursifyCourse.updateOne(
-    { _id: section.courseId, deletedAt: null },
-    { $inc: { syncVersion: 1 } }
-  );
+  const allSections = await CoursifySection.find({
+    courseId: section.courseId,
+    deletedAt: null,
+  }).lean();
+  const allComplete = allSections.length > 0 && allSections.every((s) => s.status === 'complete');
+
+  if (allComplete) {
+    await CoursifyCourse.updateOne(
+      { _id: section.courseId, deletedAt: null },
+      { $set: { authoringStatus: 'reviewing' }, $inc: { syncVersion: 1 } }
+    );
+  } else {
+    await CoursifyCourse.updateOne(
+      { _id: section.courseId, deletedAt: null },
+      { $inc: { syncVersion: 1 } }
+    );
+  }
+
   return { section: normalizeSection(section) };
+}
+
+export async function dbAddSections({ courseId, sections }) {
+  await dbConnect();
+  const course = await CoursifyCourse.findOne({ _id: courseId, deletedAt: null }).lean();
+  if (!course) throw new Error('Course not found.');
+
+  const last = await CoursifySection.findOne({ courseId, deletedAt: null })
+    .sort({ order: -1 })
+    .lean();
+  let currentOrder = last ? last.order + 1 : 0;
+
+  const docs = sections.map((s) => ({
+    courseId,
+    title: s.title.trim(),
+    sectionType: s.sectionType || 'lesson',
+    content: s.content || '',
+    quiz: { questions: s.questions || [] },
+    order: s.order !== undefined ? s.order : currentOrder++,
+    resources: s.resources || [],
+    moduleId: s.moduleId || null,
+    status: s.status || 'draft',
+    summary: s.summary || '',
+    learningGoals: s.learningGoals || [],
+    estimatedDuration: s.estimatedDuration || '',
+  }));
+
+  const created = await CoursifySection.insertMany(docs);
+  await CoursifyCourse.updateOne({ _id: courseId, deletedAt: null }, { $inc: { syncVersion: 1 } });
+  return { sections: created.map(normalizeSection) };
 }
 
 export async function dbDeleteSection({ id }) {
@@ -372,13 +473,17 @@ export async function dbDeleteSection({ id }) {
   return { deletedId: id, title: section.title };
 }
 
-export async function dbReorderSections({ courseId, sectionIds }) {
+export async function dbReorderSections({ courseId, sectionIds, moduleId }) {
   await dbConnect();
   if (!sectionIds.length) throw new Error('sectionIds must not be empty.');
+
+  const query = { courseId, deletedAt: null };
+  if (moduleId) query.moduleId = moduleId;
+
   const results = await Promise.all(
     sectionIds.map((id, index) =>
       CoursifySection.updateOne(
-        { _id: id, courseId, deletedAt: null },
+        { ...query, _id: id },
         { $set: { order: index }, $inc: { syncVersion: 1 } }
       )
     )
@@ -494,4 +599,149 @@ export async function dbResearchFindings({ courseId, findings }) {
     { $push: { researchNotes: { $each: notes } }, $inc: { syncVersion: 1 } }
   );
   return { count: notes.length };
+}
+
+export async function dbApplySuggestedModules({ courseId }) {
+  await dbConnect();
+  const course = await CoursifyCourse.findOne({ _id: courseId, deletedAt: null }).lean();
+  if (!course) throw new Error('Course not found.');
+  if (!course.outline) throw new Error('No course outline found.');
+
+  // Logic similar to suggest_modules_from_outline but internal
+  const lines = course.outline.trim().split('\n');
+  const sectionTitles = [];
+  let currentGroup = '';
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('## ') && !trimmed.toLowerCase().includes('module')) {
+      const title = trimmed.replace(/^##\s+/, '').trim();
+      if (title) sectionTitles.push({ title, group: currentGroup });
+    } else if (trimmed.startsWith('### ')) {
+      const title = trimmed.replace(/^###\s+/, '').trim();
+      if (title && title.length < 100) sectionTitles.push({ title, group: currentGroup });
+    } else if (trimmed.match(/^#{1,2}\s+(module|phase|part|step)/i)) {
+      currentGroup = trimmed.replace(/^#{1,2}\s+/, '').trim();
+    }
+  }
+
+  // Use simple foundations/core/advanced/wrap heuristic
+  const moduleKeywords = [
+    { words: ['fundamental', 'basic', 'intro', 'setup'], label: 'Foundations' },
+    { words: ['core', 'main', 'build', 'implement', 'pattern'], label: 'Core Concepts' },
+    { words: ['advanced', 'deep', 'optim', 'deploy', 'real'], label: 'Advanced & Applied' },
+    { words: ['review', 'summary', 'next', 'future', 'wrap'], label: 'Review & Next Steps' },
+  ];
+
+  function assignModule(title) {
+    const lower = title.toLowerCase();
+    for (const mk of moduleKeywords) {
+      if (mk.words.some((w) => lower.includes(w))) return mk.label;
+    }
+    return null;
+  }
+
+  const moduleMap = {};
+  for (const s of sectionTitles) {
+    const mod = s.group || assignModule(s.title) || 'General';
+    if (!moduleMap[mod]) moduleMap[mod] = { title: mod, sections: [] };
+    moduleMap[mod].sections.push(s.title);
+  }
+
+  const createdModules = [];
+  let moduleOrder = 0;
+  for (const modTitle in moduleMap) {
+    const modData = moduleMap[modTitle];
+    const newModule = await CoursifyModule.create({
+      courseId,
+      title: modTitle,
+      summary: `Covers: ${modData.sections.slice(0, 3).join(', ')}`,
+      order: moduleOrder++,
+    });
+    createdModules.push(newModule);
+
+    const sectionDocs = modData.sections.map((title, i) => ({
+      courseId,
+      moduleId: newModule._id,
+      title,
+      order: i,
+      status: 'planned',
+    }));
+    await CoursifySection.insertMany(sectionDocs);
+  }
+
+  await CoursifyCourse.updateOne({ _id: courseId, deletedAt: null }, { $inc: { syncVersion: 1 } });
+  return {
+    modulesCreated: createdModules.length,
+    moduleIds: createdModules.map((m) => m._id.toString()),
+  };
+}
+
+export async function dbSearchCourses({ query }) {
+  await dbConnect();
+  const filter = {
+    deletedAt: null,
+    $or: [
+      { title: { $regex: query, $options: 'i' } },
+      { description: { $regex: query, $options: 'i' } },
+      { tags: { $regex: query, $options: 'i' } },
+    ],
+  };
+  const courses = await CoursifyCourse.find(filter).sort({ updatedAt: -1 }).limit(20).lean();
+  return courses.map(normalizeCourse);
+}
+
+export async function dbAddSectionResource({ sectionId, resource }) {
+  await dbConnect();
+  const section = await CoursifySection.findOneAndUpdate(
+    { _id: sectionId, deletedAt: null },
+    { $push: { resources: resource }, $inc: { syncVersion: 1 } },
+    { new: true }
+  ).lean();
+  if (!section) throw new Error('Section not found.');
+  await CoursifyCourse.updateOne(
+    { _id: section.courseId, deletedAt: null },
+    { $inc: { syncVersion: 1 } }
+  );
+  return { section: normalizeSection(section) };
+}
+
+export async function dbDeleteSections({ ids }) {
+  await dbConnect();
+  const result = await CoursifySection.updateMany(
+    { _id: { $in: ids }, deletedAt: null },
+    { $set: { deletedAt: new Date() }, $inc: { syncVersion: 1 } }
+  );
+  return { deletedCount: result.modifiedCount };
+}
+
+export async function dbDeleteModules({ ids }) {
+  await dbConnect();
+  const result = await CoursifyModule.updateMany(
+    { _id: { $in: ids }, deletedAt: null },
+    { $set: { deletedAt: new Date() }, $inc: { syncVersion: 1 } }
+  );
+  // Also unassign sections
+  await CoursifySection.updateMany(
+    { moduleId: { $in: ids }, deletedAt: null },
+    { $set: { moduleId: null }, $inc: { syncVersion: 1 } }
+  );
+  return { deletedCount: result.modifiedCount };
+}
+
+export async function dbGetResearchNotes({ courseId }) {
+  await dbConnect();
+  const course = await CoursifyCourse.findOne({ _id: courseId, deletedAt: null })
+    .select('researchNotes')
+    .lean();
+  if (!course) throw new Error('Course not found.');
+  return (course.researchNotes || []).map((n) => ({
+    id: n._id?.toString() || n.id,
+    title: n.title || '',
+    summary: n.summary || '',
+    sourceUrl: n.sourceUrl || '',
+    sourceType: n.sourceType || 'other',
+    notes: n.notes || '',
+    accessedAt: n.accessedAt || null,
+  }));
 }

--- a/src/lib/mcp/coursify/tools.js
+++ b/src/lib/mcp/coursify/tools.js
@@ -27,6 +27,15 @@ import {
   dbListCourseModules,
   dbAddResearchNote,
   dbResearchFindings,
+  dbGetResearchNotes,
+  dbGetCourseWorkspace,
+  dbSearchCourses,
+  dbGetModule,
+  dbDeleteModules,
+  dbAddSections,
+  dbDeleteSections,
+  dbAddSectionResource,
+  dbApplySuggestedModules,
 } from '@/lib/coursify/db-ops.js';
 
 // Shared schemas
@@ -82,19 +91,21 @@ export function registerCoursifyTools(server) {
     {
       title: 'List Courses',
       description:
-        'Use this first before creating a course. Retrieve all Coursify courses so you can avoid duplicate topics and decide whether to create a new course or update an existing draft.',
+        'Retrieve all Coursify courses, sorted by last updated. Includes progress summary (sections complete/total) and authoringStatus.',
       annotations: READ_ONLY_ANNOTATIONS,
       inputSchema: {
         status: z
           .enum(['draft', 'published', 'all'])
           .optional()
           .describe('Filter by status. Defaults to "all".'),
+        limit: z.number().int().optional().default(20),
+        offset: z.number().int().optional().default(0),
       },
       _meta: toolMeta('Fetching courses...', 'Courses loaded.'),
     },
-    async ({ status } = {}) => {
+    async ({ status, limit, offset } = {}) => {
       try {
-        const courses = await dbListCourses({ status });
+        const courses = await dbListCourses({ status, limit, offset });
         return textResult(`Found ${courses.length} courses in Coursify.`, {
           kind: 'courses',
           courses,
@@ -106,26 +117,103 @@ export function registerCoursifyTools(server) {
   );
 
   server.registerTool(
+    'delete_modules',
+    {
+      title: 'Delete Modules (Bulk)',
+      description: 'Delete multiple modules in a single call.',
+      annotations: DESTRUCTIVE_ANNOTATIONS,
+      inputSchema: {
+        ids: z.array(z.string()).describe('Array of module IDs to delete'),
+      },
+      _meta: toolMeta('Deleting modules...', 'Modules deleted.'),
+    },
+    async ({ ids }) => {
+      try {
+        const { deletedCount } = await dbDeleteModules({ ids });
+        return textResult(`Deleted ${deletedCount} modules.`, { success: true, deletedCount });
+      } catch (err) {
+        return errorResult(`Error deleting modules: ${err.message}`);
+      }
+    }
+  );
+
+  server.registerTool(
+    'search_courses',
+    {
+      title: 'Search Courses',
+      description: 'Search for courses by title, description, or tags.',
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        query: z.string().describe('Search keyword'),
+      },
+      _meta: toolMeta('Searching courses...', 'Search complete.'),
+    },
+    async ({ query }) => {
+      try {
+        const courses = await dbSearchCourses({ query });
+        return textResult(`Found ${courses.length} courses matching "${query}".`, {
+          kind: 'courses',
+          courses,
+        });
+      } catch (err) {
+        return errorResult(`Error searching courses: ${err.message}`);
+      }
+    }
+  );
+
+  server.registerTool(
     'get_course',
     {
       title: 'Get Course',
       description:
-        'Use this before revising an existing course. Returns course metadata, planning fields, modules, and sections grouped by module — but only section titles, summaries, and statuses (NOT full content). Call get_section_content when you need the full Markdown body of a specific section.',
+        'Returns course metadata, planning fields, and module structure. Set includeSectionContent: true to also fetch all section bodies in one call.',
       annotations: READ_ONLY_ANNOTATIONS,
       inputSchema: {
         id: z.string().describe('MongoDB _id of the course'),
+        includeSectionContent: z
+          .boolean()
+          .optional()
+          .describe('If true, returns full Markdown content for all sections.'),
       },
       _meta: toolMeta('Loading course...', 'Course loaded.'),
     },
-    async ({ id }) => {
+    async ({ id, includeSectionContent }) => {
       try {
-        const { course, modules, uncategorizedSections } = await dbGetCourse({ id });
+        const { course, modules, uncategorizedSections } = await dbGetCourse({
+          id,
+          includeSectionContent,
+        });
         return textResult(
-          `Course "${course.title}" has ${modules.length} modules and ${course.sectionCount} sections. Use get_section_content to read or edit a section's full Markdown body.`,
+          `Course "${course.title}" loaded. It has ${modules.length} modules and ${course.sectionCount} sections.`,
           { kind: 'course_detail', course, modules, uncategorizedSections }
         );
       } catch (err) {
         return errorResult(`Error fetching course: ${err.message}`);
+      }
+    }
+  );
+
+  server.registerTool(
+    'get_course_workspace',
+    {
+      title: 'Get Course Workspace',
+      description:
+        'Single-call loader for session resume. Returns course metadata, planning (including agentNotes), research notes, and all modules with full section content.',
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        courseId: z.string().describe('MongoDB _id of the course'),
+      },
+      _meta: toolMeta('Loading workspace...', 'Workspace loaded.'),
+    },
+    async ({ courseId }) => {
+      try {
+        const data = await dbGetCourseWorkspace({ id: courseId });
+        return textResult(`Full workspace for "${data.course.title}" loaded.`, {
+          kind: 'course_workspace',
+          ...data,
+        });
+      } catch (err) {
+        return errorResult(`Error fetching workspace: ${err.message}`);
       }
     }
   );
@@ -267,7 +355,7 @@ export function registerCoursifyTools(server) {
     {
       title: 'Save Course Plan',
       description:
-        'Save the course planning workspace: target audience, learning objectives, prerequisites, outcome, outline (Markdown), planning notes, and authoringStatus. Call this after research and before creating modules or sections.',
+        'Save the course planning workspace. Use agentNotes to save your internal working state across sessions.',
       annotations: MUTATION_ANNOTATIONS,
       inputSchema: {
         courseId: z.string().describe('MongoDB _id of the course'),
@@ -280,6 +368,7 @@ export function registerCoursifyTools(server) {
           .optional()
           .describe('Free-form Markdown outline of planned modules and sections'),
         planningNotes: z.string().optional(),
+        agentNotes: z.string().optional().describe('Internal agent state or scratchpad'),
         authoringStatus: z
           .enum(['idea', 'researching', 'planned', 'drafting', 'reviewing', 'ready', 'published'])
           .optional(),
@@ -338,7 +427,7 @@ export function registerCoursifyTools(server) {
     {
       title: 'Suggest Modules From Outline',
       description:
-        'Read-only. Analyzes the saved course outline and returns a suggested module structure — titles, summaries, learning goals, and which outline sections belong to each module. Does NOT create modules; review the suggestions then call create_module for each you want.',
+        'Read-only analyzer for course outline. Use apply_suggested_modules to create them in one call.',
       annotations: READ_ONLY_ANNOTATIONS,
       inputSchema: {
         courseId: z.string().describe('MongoDB _id of the course'),
@@ -476,6 +565,31 @@ export function registerCoursifyTools(server) {
   );
 
   // ── Modules ───────────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'get_module',
+    {
+      title: 'Get Module',
+      description: 'Fetch details for a specific module including its sections.',
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        id: z.string().describe('MongoDB _id of the module'),
+      },
+      _meta: toolMeta('Loading module...', 'Module loaded.'),
+    },
+    async ({ id }) => {
+      try {
+        const { module, sections } = await dbGetModule({ id });
+        return textResult(`Module "${module.title}" has ${sections.length} sections.`, {
+          kind: 'module_detail',
+          module,
+          sections,
+        });
+      } catch (err) {
+        return errorResult(`Error fetching module: ${err.message}`);
+      }
+    }
+  );
 
   server.registerTool(
     'create_module',
@@ -642,7 +756,7 @@ export function registerCoursifyTools(server) {
     {
       title: 'Add Section',
       description:
-        'Use this once per planned course section after research and outlining. Specify the moduleId to group it correctly. Write full Markdown content that follows the authoring guide.',
+        'Create a single course section. Use set_quiz_questions to manage questions separately.',
       annotations: MUTATION_ANNOTATIONS,
       inputSchema: {
         courseId: z.string().describe('MongoDB _id of the course to add this section to'),
@@ -658,7 +772,9 @@ export function registerCoursifyTools(server) {
         questions: z
           .array(questionSchema)
           .optional()
-          .describe('Quiz questions. Provide 3-7 with explanations.'),
+          .describe(
+            'DEPRECATED: Use set_quiz_questions instead. Quiz questions for this section.'
+          ),
         moduleId: z
           .string()
           .optional()
@@ -720,7 +836,7 @@ export function registerCoursifyTools(server) {
     {
       title: 'Update Section',
       description:
-        'Edit the title, content, order, or resources of an existing section. Use full replacement Markdown when changing content.',
+        'Edit an existing section. Use full replacement Markdown for content. Use set_quiz_questions to manage questions. When all sections reach complete, course authoringStatus automatically advances to reviewing.',
       annotations: MUTATION_ANNOTATIONS,
       inputSchema: {
         id: z.string().describe('MongoDB _id of the section to update'),
@@ -730,7 +846,9 @@ export function registerCoursifyTools(server) {
         questions: z
           .array(questionSchema)
           .optional()
-          .describe('Full replacement quiz questions array.'),
+          .describe(
+            'DEPRECATED: Use set_quiz_questions instead. Full replacement quiz questions array.'
+          ),
         summary: z.string().optional(),
         learningGoals: z.array(z.string()).optional(),
         estimatedDuration: z.string().optional(),
@@ -778,6 +896,37 @@ export function registerCoursifyTools(server) {
   );
 
   server.registerTool(
+    'add_sections',
+    {
+      title: 'Add Sections (Batch)',
+      description: 'Create multiple sections in one call.',
+      annotations: MUTATION_ANNOTATIONS,
+      inputSchema: {
+        courseId: z.string().describe('MongoDB _id of the course'),
+        sections: z.array(
+          z.object({
+            title: z.string(),
+            moduleId: z.string().optional(),
+            sectionType: z.enum(['lesson', 'quiz']).optional(),
+            content: z.string().optional(),
+            order: z.number().int().optional(),
+            status: z.enum(['planned', 'draft', 'needs_review', 'complete']).optional(),
+          })
+        ),
+      },
+      _meta: toolMeta('Adding sections...', 'Sections added.'),
+    },
+    async ({ courseId, sections }) => {
+      try {
+        const { sections: created } = await dbAddSections({ courseId, sections });
+        return textResult(`Added ${created.length} sections.`, { success: true, sections: created });
+      } catch (err) {
+        return errorResult(`Error adding sections: ${err.message}`);
+      }
+    }
+  );
+
+  server.registerTool(
     'delete_section',
     {
       title: 'Delete Section',
@@ -799,21 +948,65 @@ export function registerCoursifyTools(server) {
   );
 
   server.registerTool(
+    'delete_sections',
+    {
+      title: 'Delete Sections (Bulk)',
+      description: 'Delete multiple sections in a single call.',
+      annotations: DESTRUCTIVE_ANNOTATIONS,
+      inputSchema: {
+        ids: z.array(z.string()).describe('Array of section IDs to delete'),
+      },
+      _meta: toolMeta('Deleting sections...', 'Sections deleted.'),
+    },
+    async ({ ids }) => {
+      try {
+        const { deletedCount } = await dbDeleteSections({ ids });
+        return textResult(`Deleted ${deletedCount} sections.`, { success: true, deletedCount });
+      } catch (err) {
+        return errorResult(`Error deleting sections: ${err.message}`);
+      }
+    }
+  );
+
+  server.registerTool(
+    'add_section_resource',
+    {
+      title: 'Add Section Resource',
+      description: 'Append a single resource link to a section.',
+      annotations: MUTATION_ANNOTATIONS,
+      inputSchema: {
+        sectionId: z.string().describe('MongoDB _id of the section'),
+        resource: resourceSchema,
+      },
+      _meta: toolMeta('Adding resource...', 'Resource added.'),
+    },
+    async ({ sectionId, resource }) => {
+      try {
+        const { section } = await dbAddSectionResource({ sectionId, resource });
+        return textResult(`Added resource to "${section.title}".`, { success: true, section });
+      } catch (err) {
+        return errorResult(`Error adding resource: ${err.message}`);
+      }
+    }
+  );
+
+  server.registerTool(
     'reorder_sections',
     {
       title: 'Reorder Sections',
       description:
-        'Set the display order of all sections in a course by providing the full ordered list of section IDs.',
+        'Set the display order of sections. Optionally provide moduleId to reorder within that module only.',
       annotations: MUTATION_ANNOTATIONS,
       inputSchema: {
         courseId: z.string().describe('MongoDB _id of the course'),
-        sectionIds: z.array(z.string()).describe('All section IDs in the desired order.'),
+        sectionIds: z.array(z.string()).describe('Ordered section IDs.'),
+        moduleId: z.string().optional().describe('Reorder within this module only.'),
       },
       _meta: toolMeta('Reordering sections...', 'Sections reordered.'),
     },
-    async ({ courseId, sectionIds }) => {
+    async ({ courseId, sectionIds, moduleId }) => {
       try {
-        const { reordered } = await dbReorderSections({ courseId, sectionIds });
+        const { reordered } = await dbReorderSections({ courseId, sectionIds, moduleId });
         return textResult(`Reordered ${reordered} sections.`, { success: true });
       } catch (err) {
         return errorResult(`Error reordering sections: ${err.message}`);
@@ -850,6 +1043,30 @@ export function registerCoursifyTools(server) {
   );
 
   // ── Research ──────────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'get_research_notes',
+    {
+      title: 'Get Research Notes',
+      description: 'Retrieve all research findings for a course.',
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        courseId: z.string().describe('MongoDB _id of the course'),
+      },
+      _meta: toolMeta('Loading research notes...', 'Research notes loaded.'),
+    },
+    async ({ courseId }) => {
+      try {
+        const notes = await dbGetResearchNotes({ courseId });
+        return textResult(`Found ${notes.length} research notes.`, {
+          kind: 'research_notes',
+          notes,
+        });
+      } catch (err) {
+        return errorResult(`Error fetching research notes: ${err.message}`);
+      }
+    }
+  );
 
   server.registerTool(
     'add_research_note',
@@ -918,6 +1135,32 @@ export function registerCoursifyTools(server) {
   );
 
   // ── Progress ──────────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'apply_suggested_modules',
+    {
+      title: 'Apply Suggested Modules',
+      description:
+        'Runs suggestions from outline and creates all modules and sections in one call.',
+      annotations: MUTATION_ANNOTATIONS,
+      inputSchema: {
+        courseId: z.string().describe('MongoDB _id of the course'),
+      },
+      _meta: toolMeta('Applying modules...', 'Modules applied.'),
+    },
+    async ({ courseId }) => {
+      try {
+        const { modulesCreated, moduleIds } = await dbApplySuggestedModules({ courseId });
+        return textResult(`Created ${modulesCreated} modules from outline.`, {
+          success: true,
+          modulesCreated,
+          moduleIds,
+        });
+      } catch (err) {
+        return errorResult(`Error applying modules: ${err.message}`);
+      }
+    }
+  );
 
   server.registerTool(
     'get_course_progress',

--- a/src/lib/mcp/coursify/utils.js
+++ b/src/lib/mcp/coursify/utils.js
@@ -32,6 +32,8 @@ export function normalizeCourse(course) {
     tags: course.tags || [],
     thumbnail: course.thumbnail || null,
     sectionCount: course.sectionCount ?? 0,
+    sectionsComplete: course.sectionsComplete ?? 0,
+    sectionsTotal: course.sectionsTotal ?? 0,
     // Planning fields
     targetAudience: course.targetAudience || '',
     learningObjectives: course.learningObjectives || [],
@@ -39,6 +41,7 @@ export function normalizeCourse(course) {
     outcome: course.outcome || '',
     outline: course.outline || '',
     planningNotes: course.planningNotes || '',
+    agentNotes: course.agentNotes || '',
     researchNotes: (course.researchNotes || []).map((n) => ({
       id: n._id?.toString?.() || n.id,
       title: n.title || '',

--- a/src/models/CoursifyCourse.js
+++ b/src/models/CoursifyCourse.js
@@ -67,6 +67,7 @@ const CoursifyCourseSchema = new mongoose.Schema(
     outcome: { type: String, default: '' },
     outline: { type: String, default: '' },
     planningNotes: { type: String, default: '' },
+    agentNotes: { type: String, default: '' },
     researchNotes: { type: [ResearchNoteSchema], default: [] },
     authoringStatus: {
       type: String,


### PR DESCRIPTION
This submission addresses 16 identified gaps in the Coursify MCP tools to improve AI agent workflow and session continuity.

Key changes:
- **Session Continuity (P0):** New `get_course_workspace` tool for full context loading; `get_research_notes` for retrieving saved findings; enhanced `list_courses` with `updatedAt` sorting and progress summaries.
- **Agent Efficiency (P1):** New `get_module` tool; batch `add_sections`; module-scoped `reorder_sections`.
- **Design Improvements (P2):** Server-side auto-advancement of course status to 'reviewing' when sections are complete; consolidated quiz management; pagination and search for courses.
- **Missing Utility (P3):** `agentNotes` scratchpad; `add_section_resource`; bulk delete for modules and sections.

Fixes #147

---
*PR created automatically by Jules for task [18230917946572890835](https://jules.google.com/task/18230917946572890835) started by @hasanraiyan*