### PR TITLE
Fix Coursify Stale Cache and Visibility Bug

### DIFF
--- a/src/app/api/coursify/courses/[id]/modules/reorder/route.js
+++ b/src/app/api/coursify/courses/[id]/modules/reorder/route.js
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/dbConnect';
 import CoursifyModule from '@/models/CoursifyModule';
 import CoursifyCourse from '@/models/CoursifyCourse';
+import { revalidatePath } from 'next/cache';
 
 export async function POST(request, { params }) {
   const auth = await requireAdminAuth(request);
@@ -31,6 +32,11 @@ export async function POST(request, { params }) {
     );
 
     await CoursifyCourse.updateOne({ _id: id, deletedAt: null }, { $inc: { syncVersion: 1 } });
+
+    const course = await CoursifyCourse.findById(id).select('slug').lean();
+    if (course?.slug) {
+      revalidatePath(`/coursify/${course.slug}`);
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/coursify/courses/[id]/modules/route.js
+++ b/src/app/api/coursify/courses/[id]/modules/route.js
@@ -4,6 +4,7 @@ import dbConnect from '@/lib/dbConnect';
 import CoursifyCourse from '@/models/CoursifyCourse';
 import CoursifyModule from '@/models/CoursifyModule';
 import CoursifySection from '@/models/CoursifySection';
+import { revalidatePath } from 'next/cache';
 
 export async function GET(request, { params }) {
   const auth = await requireAdminAuth(request);
@@ -75,6 +76,10 @@ export async function POST(request, { params }) {
       learningGoals: Array.isArray(learningGoals) ? learningGoals : [],
       order: resolvedOrder,
     });
+
+    if (course.slug) {
+      revalidatePath(`/coursify/${course.slug}`);
+    }
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/coursify/courses/[id]/publish/route.js
+++ b/src/app/api/coursify/courses/[id]/publish/route.js
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { dbUpdateCourse } from '@/lib/coursify/db-ops';
 import dbConnect from '@/lib/dbConnect';
 import CoursifyCourse from '@/models/CoursifyCourse';
+import { revalidatePath } from 'next/cache';
 
 export async function POST(request, { params }) {
   const auth = await requireAdminAuth(request);
@@ -19,6 +20,9 @@ export async function POST(request, { params }) {
 
     const newStatus = course.status === 'published' ? 'draft' : 'published';
     const { course: updated } = await dbUpdateCourse({ id, status: newStatus });
+
+    revalidatePath('/coursify');
+    revalidatePath(`/coursify/${updated.slug}`);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/coursify/courses/[id]/reorder/route.js
+++ b/src/app/api/coursify/courses/[id]/reorder/route.js
@@ -2,6 +2,8 @@ import { requireAdminAuth } from '@/lib/money-auth';
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/dbConnect';
 import CoursifySection from '@/models/CoursifySection';
+import CoursifyCourse from '@/models/CoursifyCourse';
+import { revalidatePath } from 'next/cache';
 
 export async function POST(request, { params }) {
   const auth = await requireAdminAuth(request);
@@ -27,6 +29,11 @@ export async function POST(request, { params }) {
         )
       )
     );
+
+    const course = await CoursifyCourse.findById(id).select('slug').lean();
+    if (course?.slug) {
+      revalidatePath(`/coursify/${course.slug}`);
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/coursify/courses/[id]/route.js
+++ b/src/app/api/coursify/courses/[id]/route.js
@@ -6,6 +6,7 @@ import CoursifyModule from '@/models/CoursifyModule';
 import CoursifySection from '@/models/CoursifySection';
 import { generateUniqueSlug } from '@/lib/coursify/slugify';
 import mongoose from 'mongoose';
+import { revalidatePath } from 'next/cache';
 
 function isObjectId(str) {
   return mongoose.Types.ObjectId.isValid(str) && String(new mongoose.Types.ObjectId(str)) === str;
@@ -97,6 +98,9 @@ export async function PATCH(request, { params }) {
       return NextResponse.json({ success: false, error: 'Course not found' }, { status: 404 });
     }
 
+    revalidatePath('/coursify');
+    revalidatePath(`/coursify/${course.slug}`);
+
     return NextResponse.json({ success: true, course: { ...course, _id: course._id.toString() } });
   } catch (error) {
     return NextResponse.json({ success: false, error: error.message }, { status: 500 });
@@ -125,6 +129,11 @@ export async function DELETE(request, { params }) {
       CoursifySection.updateMany({ courseId: id, deletedAt: null }, { $set: { deletedAt } }),
       CoursifyModule.updateMany({ courseId: id, deletedAt: null }, { $set: { deletedAt } }),
     ]);
+
+    revalidatePath('/coursify');
+    if (course.slug) {
+      revalidatePath(`/coursify/${course.slug}`);
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/coursify/courses/[id]/sections/route.js
+++ b/src/app/api/coursify/courses/[id]/sections/route.js
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/dbConnect';
 import CoursifyCourse from '@/models/CoursifyCourse';
 import CoursifySection from '@/models/CoursifySection';
+import { revalidatePath } from 'next/cache';
 
 export async function POST(request, { params }) {
   const auth = await requireAdminAuth(request);
@@ -50,6 +51,10 @@ export async function POST(request, { params }) {
       learningGoals: Array.isArray(learningGoals) ? learningGoals : [],
       estimatedDuration: estimatedDuration || '',
     });
+
+    if (course.slug) {
+      revalidatePath(`/coursify/${course.slug}`);
+    }
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/coursify/modules/[id]/route.js
+++ b/src/app/api/coursify/modules/[id]/route.js
@@ -5,6 +5,7 @@ import CoursifyModule from '@/models/CoursifyModule';
 import CoursifySection from '@/models/CoursifySection';
 import CoursifyCourse from '@/models/CoursifyCourse';
 import mongoose from 'mongoose';
+import { revalidatePath } from 'next/cache';
 
 const ALLOWED_PATCH_KEYS = ['title', 'summary', 'learningGoals', 'order', 'status'];
 
@@ -46,6 +47,11 @@ export async function PATCH(request, { params }) {
       { $inc: { syncVersion: 1 } }
     );
 
+    const course = await CoursifyCourse.findById(module.courseId).select('slug').lean();
+    if (course?.slug) {
+      revalidatePath(`/coursify/${course.slug}`);
+    }
+
     return NextResponse.json({
       success: true,
       module: { ...module, _id: module._id.toString(), courseId: module.courseId.toString() },
@@ -86,6 +92,11 @@ export async function DELETE(request, { params }) {
       { _id: module.courseId, deletedAt: null },
       { $inc: { syncVersion: 1 } }
     );
+
+    const course = await CoursifyCourse.findById(module.courseId).select('slug').lean();
+    if (course?.slug) {
+      revalidatePath(`/coursify/${course.slug}`);
+    }
 
     return NextResponse.json({ success: true, deletedId: id });
   } catch (error) {

--- a/src/app/api/coursify/sections/[id]/route.js
+++ b/src/app/api/coursify/sections/[id]/route.js
@@ -2,7 +2,9 @@ import { requireAdminAuth } from '@/lib/money-auth';
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/dbConnect';
 import CoursifySection from '@/models/CoursifySection';
+import CoursifyCourse from '@/models/CoursifyCourse';
 import mongoose from 'mongoose';
+import { revalidatePath } from 'next/cache';
 
 function isObjectId(str) {
   return mongoose.Types.ObjectId.isValid(str) && String(new mongoose.Types.ObjectId(str)) === str;
@@ -80,6 +82,11 @@ export async function PATCH(request, { params }) {
       return NextResponse.json({ success: false, error: 'Section not found' }, { status: 404 });
     }
 
+    const course = await CoursifyCourse.findById(section.courseId).select('slug').lean();
+    if (course?.slug) {
+      revalidatePath(`/coursify/${course.slug}`);
+    }
+
     return NextResponse.json({
       success: true,
       section: {
@@ -113,6 +120,11 @@ export async function DELETE(request, { params }) {
 
     if (!section) {
       return NextResponse.json({ success: false, error: 'Section not found' }, { status: 404 });
+    }
+
+    const course = await CoursifyCourse.findById(section.courseId).select('slug').lean();
+    if (course?.slug) {
+      revalidatePath(`/coursify/${course.slug}`);
     }
 
     return NextResponse.json({ success: true });

--- a/src/app/coursify/[slug]/page.js
+++ b/src/app/coursify/[slug]/page.js
@@ -2,8 +2,6 @@ import { notFound } from 'next/navigation';
 import { fetchPublicCourse } from '@/lib/coursify/public-fetch';
 import { CourseReaderShell } from '@/components/coursify/reader/CourseReaderShell';
 
-export const revalidate = 3600;
-
 export default async function CoursePage({ params }) {
   const { slug } = await params;
   const data = await fetchPublicCourse(slug);

--- a/src/lib/coursify/public-fetch.js
+++ b/src/lib/coursify/public-fetch.js
@@ -46,23 +46,23 @@ export async function fetchPublicCourse(slugOrId) {
   const courseId = course._id.toString();
 
   const [modules, sections] = await Promise.all([
-    CoursifyModule.find({ courseId, status: 'complete', deletedAt: null })
+    CoursifyModule.find({ courseId, deletedAt: null })
       .select('title summary order')
       .sort({ order: 1 })
       .lean(),
-    CoursifySection.find({ courseId, status: 'complete', deletedAt: null })
+    CoursifySection.find({ courseId, deletedAt: null })
       .select('title blocks resources order moduleId summary learningGoals estimatedDuration')
       .sort({ order: 1 })
       .lean(),
   ]);
 
-  const completeModuleIds = new Set(modules.map((m) => m._id.toString()));
+  const moduleIds = new Set(modules.map((m) => m._id.toString()));
 
   return {
     course: ser(course),
     modules: modules.map((m) => ser(m)),
     sections: sections
-      .filter((s) => !s.moduleId || completeModuleIds.has(s.moduleId.toString()))
+      .filter((s) => !s.moduleId || moduleIds.has(s.moduleId.toString()))
       .map((s) => {
         const flat = ser({ ...s, courseId, moduleId: s.moduleId?.toString() || null });
         if (flat.blocks) {


### PR DESCRIPTION
This PR addresses critical bugs in Coursify where course visibility and content updates were not reflected on public pages due to aggressive Next.js caching and missing revalidation logic.

Key changes:
1. **On-Demand Revalidation**: Added `revalidatePath` calls to all relevant API routes (publish, course update/delete, section/module mutations, and reordering). This ensures that any change in the Studio immediately clears the cache for the course list (`/coursify`) and the specific course page.
2. **Dynamic Page Config**: Removed the hardcoded `revalidate = 3600` from `src/app/coursify/[slug]/page.js`. The page now updates instantly when triggered by the API.
3. **Content Visibility**: Modified `src/lib/coursify/public-fetch.js` to remove the strict `status: 'complete'` filter on modules and sections. Now, once a course is published, all its constituent content is visible to the public, preventing sections from being silently omitted if they weren't explicitly marked as complete.
4. **Verification**: Verified the implementation across all affected API routes and core fetching logic.

Fixes #162

---
*PR created automatically by Jules for task [13243208134610655242](https://jules.google.com/task/13243208134610655242) started by @hasanraiyan*