### PR TITLE
Coursify Course Freezing & Immutable Authoring

### DIFF
--- a/.agent/skills/coursify-studio/scripts/coursify.js
+++ b/.agent/skills/coursify-studio/scripts/coursify.js
@@ -224,7 +224,12 @@ courses
       updateIdMap(c.title, c.id);
     });
 
-    console.log(JSON.stringify(result, null, 2));
+    const output = result.map((c) => ({
+      ...c,
+      title: c.isFrozen ? `[FROZEN] ${c.title}` : c.title,
+    }));
+
+    console.log(JSON.stringify(output, null, 2));
   });
 
 courses
@@ -288,47 +293,88 @@ courses
     if (payload.id) payload.id = resolveFromCache(payload.id);
 
     logVerbose('Upserting course with payload', payload);
-    const PLAN_KEYS = [
-      'targetAudience',
-      'learningObjectives',
-      'prerequisites',
-      'outcome',
-      'outline',
-      'authoringStatus',
-      'agentNotes',
-    ];
-
-    let result;
-    if (!payload.id) {
-      result = await dbOps.dbCreateCourse(payload);
-      const hasPlanFields = PLAN_KEYS.some((k) => payload[k] !== undefined);
-      if (hasPlanFields) {
-        result = await dbOps.dbSaveCoursePlan({ courseId: result.course.id, ...payload });
-      }
-    } else {
-      const BASIC_KEYS = [
-        'title',
-        'description',
-        'difficulty',
-        'estimatedDuration',
-        'tags',
-        'status',
+    try {
+      const PLAN_KEYS = [
+        'targetAudience',
+        'learningObjectives',
+        'prerequisites',
+        'outcome',
+        'outline',
+        'authoringStatus',
+        'agentNotes',
       ];
-      const hasBasic = BASIC_KEYS.some((k) => payload[k] !== undefined);
-      const hasPlan = PLAN_KEYS.some((k) => payload[k] !== undefined);
-      const id = payload.id;
 
-      if (hasBasic && hasPlan) {
-        await dbOps.dbUpdateCourse(payload);
-        result = await dbOps.dbSaveCoursePlan({ courseId: id, ...payload });
-      } else if (hasPlan) {
-        result = await dbOps.dbSaveCoursePlan({ courseId: id, ...payload });
+      let result;
+      if (!payload.id) {
+        result = await dbOps.dbCreateCourse(payload);
+        const hasPlanFields = PLAN_KEYS.some((k) => payload[k] !== undefined);
+        if (hasPlanFields) {
+          result = await dbOps.dbSaveCoursePlan({ courseId: result.course.id, ...payload });
+        }
       } else {
-        result = await dbOps.dbUpdateCourse(payload);
+        const BASIC_KEYS = [
+          'title',
+          'description',
+          'difficulty',
+          'estimatedDuration',
+          'tags',
+          'status',
+          'isFrozen',
+        ];
+        const hasBasic = BASIC_KEYS.some((k) => payload[k] !== undefined);
+        const hasPlan = PLAN_KEYS.some((k) => payload[k] !== undefined);
+        const id = payload.id;
+
+        if (hasBasic && hasPlan) {
+          await dbOps.dbUpdateCourse(payload);
+          result = await dbOps.dbSaveCoursePlan({ courseId: id, ...payload });
+        } else if (hasPlan) {
+          result = await dbOps.dbSaveCoursePlan({ courseId: id, ...payload });
+        } else {
+          result = await dbOps.dbUpdateCourse(payload);
+        }
       }
+      updateIdMap(result.course.slug, result.course.id);
+      console.log(JSON.stringify(result, null, 2));
+    } catch (err) {
+      handleFrozenError(err, payload.id || payload.title);
     }
-    updateIdMap(result.course.slug, result.course.id);
-    console.log(JSON.stringify(result, null, 2));
+  });
+
+courses
+  .command('freeze <id>')
+  .description('Freeze a course (makes it read-only)')
+  .action(async (id) => {
+    await connect();
+    const resolvedId = resolveFromCache(id);
+    try {
+      const result = await dbOps.dbUpdateCourse({ id: resolvedId, isFrozen: true });
+      console.log(
+        JSON.stringify({ success: true, message: `Course "${result.course.title}" frozen.` }, null, 2)
+      );
+    } catch (err) {
+      handleFrozenError(err, id);
+    }
+  });
+
+courses
+  .command('unfreeze <id>')
+  .description('Unfreeze a course (allows editing again)')
+  .action(async (id) => {
+    await connect();
+    const resolvedId = resolveFromCache(id);
+    try {
+      const result = await dbOps.dbUpdateCourse({ id: resolvedId, isFrozen: false });
+      console.log(
+        JSON.stringify(
+          { success: true, message: `Course "${result.course.title}" unfrozen.` },
+          null,
+          2
+        )
+      );
+    } catch (err) {
+      handleFrozenError(err, id);
+    }
   });
 
 courses
@@ -360,10 +406,14 @@ modules
     payload.courseId = resolveFromCache(payload.courseId);
 
     const { id, courseId, ...fields } = payload;
-    const result = id
-      ? await dbOps.dbUpdateModule({ id, ...fields })
-      : await dbOps.dbCreateModule({ courseId, ...fields });
-    console.log(JSON.stringify(result, null, 2));
+    try {
+      const result = id
+        ? await dbOps.dbUpdateModule({ id, ...fields })
+        : await dbOps.dbCreateModule({ courseId, ...fields });
+      console.log(JSON.stringify(result, null, 2));
+    } catch (err) {
+      handleFrozenError(err, courseId);
+    }
   });
 
 modules
@@ -374,8 +424,12 @@ modules
   .action(async (ids, options) => {
     await connect();
     const courseId = resolveFromCache(options.courseId);
-    const result = await dbOps.dbReorderModules({ courseId, moduleIds: ids });
-    console.log(JSON.stringify(result, null, 2));
+    try {
+      const result = await dbOps.dbReorderModules({ courseId, moduleIds: ids });
+      console.log(JSON.stringify(result, null, 2));
+    } catch (err) {
+      handleFrozenError(err, courseId);
+    }
   });
 
 modules
@@ -383,8 +437,12 @@ modules
   .description('Soft-delete one or more modules')
   .action(async (ids) => {
     await connect();
-    const result = await dbOps.dbDeleteModules({ ids });
-    console.log(JSON.stringify(result, null, 2));
+    try {
+      const result = await dbOps.dbDeleteModules({ ids });
+      console.log(JSON.stringify(result, null, 2));
+    } catch (err) {
+      handleFrozenError(err, 'Selected Module(s)');
+    }
   });
 
 // 4. Section Operations
@@ -448,9 +506,16 @@ sections
         const issues = lintContent(file, content);
         results.push({ file, title, issues, action: 'skip (dry-run)' });
       } else {
-        logVerbose(`Syncing section: ${title} from ${file}`);
-        const result = await dbOps.dbAddSection(payload);
-        results.push({ file, title, sectionId: result.section.id, action: 'created' });
+        try {
+          logVerbose(`Syncing section: ${title} from ${file}`);
+          const result = await dbOps.dbAddSection(payload);
+          results.push({ file, title, sectionId: result.section.id, action: 'created' });
+        } catch (err) {
+          if (err.message.includes('frozen')) {
+            handleFrozenError(err, courseId);
+          }
+          results.push({ file, title, error: err.message, action: 'failed' });
+        }
       }
     }
 
@@ -499,13 +564,17 @@ sections
     }
 
     logVerbose('Upserting section with payload', fields);
-    let result;
-    if (id) {
-      result = await dbOps.dbUpdateSection({ id, ...fields });
-    } else {
-      result = await dbOps.dbAddSection(fields);
+    try {
+      let result;
+      if (id) {
+        result = await dbOps.dbUpdateSection({ id, ...fields });
+      } else {
+        result = await dbOps.dbAddSection(fields);
+      }
+      console.log(JSON.stringify(result, null, 2));
+    } catch (err) {
+      handleFrozenError(err, courseId);
     }
-    console.log(JSON.stringify(result, null, 2));
   });
 
 sections
@@ -517,12 +586,16 @@ sections
   .action(async (ids, options) => {
     await connect();
     const courseId = resolveFromCache(options.courseId);
-    const result = await dbOps.dbReorderSections({
-      courseId,
-      moduleId: options.moduleId,
-      sectionIds: ids,
-    });
-    console.log(JSON.stringify(result, null, 2));
+    try {
+      const result = await dbOps.dbReorderSections({
+        courseId,
+        moduleId: options.moduleId,
+        sectionIds: ids,
+      });
+      console.log(JSON.stringify(result, null, 2));
+    } catch (err) {
+      handleFrozenError(err, courseId);
+    }
   });
 
 sections
@@ -530,8 +603,12 @@ sections
   .description('Soft-delete one or more sections')
   .action(async (ids) => {
     await connect();
-    const result = await dbOps.dbDeleteSections({ ids });
-    console.log(JSON.stringify(result, null, 2));
+    try {
+      const result = await dbOps.dbDeleteSections({ ids });
+      console.log(JSON.stringify(result, null, 2));
+    } catch (err) {
+      handleFrozenError(err, 'Selected Section(s)');
+    }
   });
 
 // 5. Research Operations
@@ -550,11 +627,28 @@ research
       console.error('Research file must contain an array of findings');
       process.exit(1);
     }
-    const result = await dbOps.dbResearchFindings({ courseId, findings });
-    console.log(JSON.stringify(result, null, 2));
+    try {
+      const result = await dbOps.dbResearchFindings({ courseId, findings });
+      console.log(JSON.stringify(result, null, 2));
+    } catch (err) {
+      handleFrozenError(err, courseId);
+    }
   });
 
 // --- Utility for File Parsing ---
+
+function handleFrozenError(err, idOrSlug) {
+  if (err.message.includes('frozen')) {
+    console.error(`\n❌ Error: Cannot modify content.`);
+    console.error(`The course "${idOrSlug}" is currently frozen.`);
+    console.error(
+      `To make changes, unfreeze it first using: \`node .agent/skills/coursify-studio/scripts/coursify.js courses unfreeze ${idOrSlug}\`\n`
+    );
+    process.exit(1);
+  }
+  console.error(JSON.stringify({ success: false, error: err.message }, null, 2));
+  process.exit(1);
+}
 
 function parseJsonFile(filePath) {
   if (!filePath) return {};

--- a/src/app/api/coursify/courses/[id]/route.js
+++ b/src/app/api/coursify/courses/[id]/route.js
@@ -70,6 +70,7 @@ export async function PATCH(request, { params }) {
       'tags',
       'thumbnail',
       'status',
+      'isFrozen',
       // Planning fields
       'targetAudience',
       'learningObjectives',

--- a/src/components/coursify/studio/AuthoringHeader.js
+++ b/src/components/coursify/studio/AuthoringHeader.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { RefreshCw, Globe, Lock, Pencil } from 'lucide-react';
+import { RefreshCw, Globe, Lock, Pencil, Snowflake } from 'lucide-react';
 import { ReaderHeader } from '@/components/coursify/reader/ReaderHeader';
 import { useCoursifyStudio } from '@/context/CoursifyStudioContext';
 
@@ -53,13 +53,21 @@ export function AuthoringHeader() {
             <RefreshCw className="w-3.5 h-3.5" />
           </button>
 
+          {course.isFrozen && (
+            <div className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-xl text-xs font-bold bg-blue-50 border border-blue-200 text-blue-700">
+              <Snowflake className="w-3 h-3 shrink-0" />
+              <span className="hidden sm:inline">Frozen</span>
+            </div>
+          )}
+
           <button
             onClick={handleTogglePublish}
+            disabled={course.isFrozen}
             className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-xl text-xs font-bold border transition-colors ${
               course.status === 'published'
                 ? 'bg-emerald-50 border-emerald-200 text-emerald-700'
                 : 'bg-white border-[#e5e3d8] text-[#7c8e88] hover:border-[#1f644e] hover:text-[#1f644e]'
-            }`}
+            } ${course.isFrozen ? 'opacity-50 cursor-not-allowed' : ''}`}
           >
             {course.status === 'published' ? (
               <Globe className="w-3 h-3 shrink-0" />

--- a/src/components/coursify/studio/ModuleSectionList.js
+++ b/src/components/coursify/studio/ModuleSectionList.js
@@ -62,7 +62,7 @@ export function ModuleSectionList() {
       ) : course.thumbnail ? (
         <div className="w-full aspect-video rounded-2xl overflow-hidden mb-8 border border-[#e5e3d8] shadow-sm relative group">
           <img src={course.thumbnail} alt={course.title} className="w-full h-full object-cover" />
-          {editMode && (
+          {editMode && !course.isFrozen && (
             <button
               onClick={() => thumbnailInputRef.current?.click()}
               disabled={thumbnailUploading}
@@ -79,7 +79,7 @@ export function ModuleSectionList() {
             </button>
           )}
         </div>
-      ) : editMode ? (
+      ) : editMode && !course.isFrozen ? (
         <button
           onClick={() => thumbnailInputRef.current?.click()}
           disabled={thumbnailUploading}
@@ -97,7 +97,7 @@ export function ModuleSectionList() {
           modules={modules}
           onNavigateTo={navigateTo}
           hideThumbnail={true}
-          editMode={editMode}
+          editMode={editMode && !course.isFrozen}
           onUpdateMeta={handleUpdateMeta}
           isSaving={planSaving}
         />
@@ -115,7 +115,7 @@ export function ModuleSectionList() {
             <h2 className="text-xl lg:text-2xl font-bold text-[#1e3a34] leading-snug min-w-0">
               {currentSection.title}
             </h2>
-            {editMode && (
+            {editMode && !course.isFrozen && (
               <div className="flex items-center gap-1 shrink-0">
                 <button
                   onClick={() => setEditingSection(currentSection)}

--- a/src/components/coursify/studio/PlanningWorkspace.js
+++ b/src/components/coursify/studio/PlanningWorkspace.js
@@ -52,7 +52,7 @@ export function PlanningWorkspace() {
     <div className="max-w-3xl mx-auto px-4 lg:px-10 py-8 space-y-6">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-bold text-[#1e3a34]">Planning Workspace</h2>
-        {editMode && planDraft && (
+        {editMode && planDraft && !course.isFrozen && (
           <button
             onClick={handleSavePlan}
             disabled={planSaving}
@@ -69,7 +69,7 @@ export function PlanningWorkspace() {
       </div>
 
       <PlanCard label="Authoring Status">
-        {editMode && planDraft ? (
+        {editMode && planDraft && !course.isFrozen ? (
           <select
             value={planDraft.authoringStatus}
             onChange={(e) => setPlanDraft((d) => ({ ...d, authoringStatus: e.target.value }))}
@@ -93,7 +93,7 @@ export function PlanningWorkspace() {
       </PlanCard>
 
       <PlanCard label="Target Audience">
-        {editMode && planDraft ? (
+        {editMode && planDraft && !course.isFrozen ? (
           <textarea
             rows={2}
             value={planDraft.targetAudience}
@@ -107,7 +107,7 @@ export function PlanningWorkspace() {
       </PlanCard>
 
       <PlanCard label="Learning Objectives">
-        {editMode && planDraft ? (
+        {editMode && planDraft && !course.isFrozen ? (
           <textarea
             rows={4}
             value={planDraft.learningObjectives}
@@ -130,7 +130,7 @@ export function PlanningWorkspace() {
       </PlanCard>
 
       <PlanCard label="Prerequisites">
-        {editMode && planDraft ? (
+        {editMode && planDraft && !course.isFrozen ? (
           <textarea
             rows={3}
             value={planDraft.prerequisites}
@@ -153,7 +153,7 @@ export function PlanningWorkspace() {
       </PlanCard>
 
       <PlanCard label="Outcome">
-        {editMode && planDraft ? (
+        {editMode && planDraft && !course.isFrozen ? (
           <textarea
             rows={2}
             value={planDraft.outcome}
@@ -167,7 +167,7 @@ export function PlanningWorkspace() {
       </PlanCard>
 
       <PlanCard label="Outline">
-        {editMode && planDraft ? (
+        {editMode && planDraft && !course.isFrozen ? (
           <textarea
             rows={8}
             value={planDraft.outline}
@@ -185,7 +185,7 @@ export function PlanningWorkspace() {
       </PlanCard>
 
       <PlanCard label="Planning Notes">
-        {editMode && planDraft ? (
+        {editMode && planDraft && !course.isFrozen ? (
           <textarea
             rows={3}
             value={planDraft.planningNotes}
@@ -205,7 +205,8 @@ export function PlanningWorkspace() {
           </h3>
           <button
             onClick={() => setShowNoteForm(!showNoteForm)}
-            className="flex items-center gap-1 px-2.5 py-1 bg-[#f0f5f2] hover:bg-[#e0ede8] text-[#1f644e] text-xs font-bold rounded-lg transition-colors"
+            disabled={course.isFrozen}
+            className={`flex items-center gap-1 px-2.5 py-1 bg-[#f0f5f2] hover:bg-[#e0ede8] text-[#1f644e] text-xs font-bold rounded-lg transition-colors ${course.isFrozen ? 'opacity-50 cursor-not-allowed' : ''}`}
           >
             <Plus className="w-3 h-3" />
             Add Note
@@ -288,13 +289,15 @@ export function PlanningWorkspace() {
                     <span className="text-[10px] font-bold px-1.5 py-0.5 bg-[#f0f5f2] rounded text-[#7c8e88] capitalize">
                       {note.sourceType || 'other'}
                     </span>
-                    <button
-                      onClick={() => handleDeleteNote(i)}
-                      className="p-1 rounded-md hover:bg-red-50 text-[#7c8e88] hover:text-[#c94c4c] transition-colors"
-                      title="Delete note"
-                    >
-                      <Trash2 className="w-3 h-3" />
-                    </button>
+                    {!course.isFrozen && (
+                      <button
+                        onClick={() => handleDeleteNote(i)}
+                        className="p-1 rounded-md hover:bg-red-50 text-[#7c8e88] hover:text-[#c94c4c] transition-colors"
+                        title="Delete note"
+                      >
+                        <Trash2 className="w-3 h-3" />
+                      </button>
+                    )}
                   </div>
                 </div>
                 {note.summary && (

--- a/src/lib/coursify/db-ops.js
+++ b/src/lib/coursify/db-ops.js
@@ -48,6 +48,22 @@ async function resolveCourseId(idOrSlug) {
   return course._id.toString();
 }
 
+/**
+ * Ensures the course is not frozen before allowing mutations.
+ */
+async function ensureNotFrozen(idOrSlug, isFrozenToggle = false) {
+  if (isFrozenToggle) return; // Explicitly allowed
+
+  await dbConnect();
+  const courseId = await resolveCourseId(idOrSlug);
+  const course = await CoursifyCourse.findOne({ _id: courseId, deletedAt: null })
+    .select('isFrozen')
+    .lean();
+  if (course?.isFrozen) {
+    throw new Error('Course is frozen and cannot be modified.');
+  }
+}
+
 // ─── Courses ──────────────────────────────────────────────────────────────────
 
 export async function dbListCourses({ status, limit = 20, offset = 0 } = {}) {
@@ -196,10 +212,20 @@ export async function dbUpdateCourse({
   estimatedDuration,
   tags,
   status,
+  isFrozen,
 }) {
   await dbConnect();
   const courseId = await resolveCourseId(id);
-  const clean = cleanPatch({ title, description, difficulty, estimatedDuration, tags, status });
+  await ensureNotFrozen(courseId, isFrozen !== undefined);
+  const clean = cleanPatch({
+    title,
+    description,
+    difficulty,
+    estimatedDuration,
+    tags,
+    status,
+    isFrozen,
+  });
   if (clean.title) clean.slug = await generateUniqueSlug(clean.title, courseId);
   if (clean.status === 'published') clean.authoringStatus = 'published';
 
@@ -229,6 +255,7 @@ export async function dbPublishCourse({ id }) {
 export async function dbDeleteCourse({ id }) {
   await dbConnect();
   const courseId = await resolveCourseId(id);
+  await ensureNotFrozen(courseId);
   const deletedAt = new Date();
   const course = await CoursifyCourse.findOneAndUpdate(
     { _id: courseId, deletedAt: null },
@@ -261,6 +288,7 @@ export async function dbSaveCoursePlan({
 }) {
   await dbConnect();
   const courseId = await resolveCourseId(id);
+  await ensureNotFrozen(courseId);
   const clean = cleanPatch({
     targetAudience,
     learningObjectives,
@@ -286,6 +314,7 @@ export async function dbSaveCoursePlan({
 export async function dbCreateModule({ courseId: id, title, summary, learningGoals, order }) {
   await dbConnect();
   const courseId = await resolveCourseId(id);
+  await ensureNotFrozen(courseId);
   const course = await CoursifyCourse.findOne({ _id: courseId, deletedAt: null }).lean();
   if (!course) throw new Error('Course not found.');
 
@@ -325,6 +354,10 @@ export async function dbGetModule({ id }) {
 
 export async function dbUpdateModule({ id, title, summary, learningGoals, order, status }) {
   await dbConnect();
+  const existing = await CoursifyModule.findOne({ _id: id, deletedAt: null }).select('courseId').lean();
+  if (!existing) throw new Error('Module not found.');
+  await ensureNotFrozen(existing.courseId);
+
   const clean = cleanPatch({ title, summary, learningGoals, order, status });
   const module = await CoursifyModule.findOneAndUpdate(
     { _id: id, deletedAt: null },
@@ -341,6 +374,10 @@ export async function dbUpdateModule({ id, title, summary, learningGoals, order,
 
 export async function dbDeleteModule({ id }) {
   await dbConnect();
+  const existing = await CoursifyModule.findOne({ _id: id, deletedAt: null }).select('courseId').lean();
+  if (!existing) throw new Error('Module not found.');
+  await ensureNotFrozen(existing.courseId);
+
   const module = await CoursifyModule.findOneAndUpdate(
     { _id: id, deletedAt: null },
     { $set: { deletedAt: new Date() }, $inc: { syncVersion: 1 } }
@@ -359,6 +396,7 @@ export async function dbDeleteModule({ id }) {
 
 export async function dbReorderModules({ courseId, moduleIds }) {
   await dbConnect();
+  await ensureNotFrozen(courseId);
   if (!moduleIds.length) throw new Error('moduleIds must not be empty.');
   const results = await Promise.all(
     moduleIds.map((id, index) =>
@@ -392,6 +430,7 @@ export async function dbAddSection({
 }) {
   await dbConnect();
   const courseId = await resolveCourseId(id);
+  await ensureNotFrozen(courseId);
   const course = await CoursifyCourse.findOne({ _id: courseId, deletedAt: null }).lean();
   if (!course) throw new Error('Course not found.');
 
@@ -430,6 +469,10 @@ export async function dbUpdateSection({
   resources,
 }) {
   await dbConnect();
+  const existing = await CoursifySection.findOne({ _id: id, deletedAt: null }).select('courseId').lean();
+  if (!existing) throw new Error('Section not found.');
+  await ensureNotFrozen(existing.courseId);
+
   const clean = cleanPatch({
     title,
     blocks: blocks || (content ? parseMarkdownToBlocks(content) : undefined),
@@ -470,6 +513,7 @@ export async function dbUpdateSection({
 
 export async function dbAddSections({ courseId, sections }) {
   await dbConnect();
+  await ensureNotFrozen(courseId);
   const course = await CoursifyCourse.findOne({ _id: courseId, deletedAt: null }).lean();
   if (!course) throw new Error('Course not found.');
 
@@ -498,6 +542,10 @@ export async function dbAddSections({ courseId, sections }) {
 
 export async function dbDeleteSection({ id }) {
   await dbConnect();
+  const existing = await CoursifySection.findOne({ _id: id, deletedAt: null }).select('courseId').lean();
+  if (!existing) throw new Error('Section not found.');
+  await ensureNotFrozen(existing.courseId);
+
   const section = await CoursifySection.findOneAndUpdate(
     { _id: id, deletedAt: null },
     { $set: { deletedAt: new Date() }, $inc: { syncVersion: 1 } }
@@ -513,6 +561,7 @@ export async function dbDeleteSection({ id }) {
 export async function dbReorderSections({ courseId: id, sectionIds, moduleId }) {
   await dbConnect();
   const courseId = await resolveCourseId(id);
+  await ensureNotFrozen(courseId);
   if (!sectionIds.length) throw new Error('sectionIds must not be empty.');
 
   const query = { courseId, deletedAt: null };
@@ -590,6 +639,7 @@ export async function dbAddResearchNote({
 }) {
   await dbConnect();
   const courseId = await resolveCourseId(id);
+  await ensureNotFrozen(courseId);
   const note = {
     title: title.trim(),
     summary: summary.trim(),
@@ -610,6 +660,7 @@ export async function dbAddResearchNote({
 export async function dbResearchFindings({ courseId: id, findings }) {
   await dbConnect();
   const courseId = await resolveCourseId(id);
+  await ensureNotFrozen(courseId);
   const course = await CoursifyCourse.findOne({ _id: courseId, deletedAt: null }).lean();
   if (!course) throw new Error('Course not found.');
   if (!findings?.length) throw new Error('Provide at least one finding.');
@@ -643,6 +694,10 @@ export async function dbSearchCourses({ query }) {
 
 export async function dbAddSectionResource({ sectionId, resource }) {
   await dbConnect();
+  const existing = await CoursifySection.findOne({ _id: sectionId, deletedAt: null }).select('courseId').lean();
+  if (!existing) throw new Error('Section not found.');
+  await ensureNotFrozen(existing.courseId);
+
   const section = await CoursifySection.findOneAndUpdate(
     { _id: sectionId, deletedAt: null },
     { $push: { resources: resource }, $inc: { syncVersion: 1 } },
@@ -658,6 +713,10 @@ export async function dbAddSectionResource({ sectionId, resource }) {
 
 export async function dbDeleteSections({ ids }) {
   await dbConnect();
+  if (!ids.length) return { deletedCount: 0 };
+  const first = await CoursifySection.findOne({ _id: ids[0] }).select('courseId').lean();
+  if (first) await ensureNotFrozen(first.courseId);
+
   const result = await CoursifySection.updateMany(
     { _id: { $in: ids }, deletedAt: null },
     { $set: { deletedAt: new Date() }, $inc: { syncVersion: 1 } }
@@ -667,6 +726,10 @@ export async function dbDeleteSections({ ids }) {
 
 export async function dbDeleteModules({ ids }) {
   await dbConnect();
+  if (!ids.length) return { deletedCount: 0 };
+  const first = await CoursifyModule.findOne({ _id: ids[0] }).select('courseId').lean();
+  if (first) await ensureNotFrozen(first.courseId);
+
   const deletedAt = new Date();
   const result = await CoursifyModule.updateMany(
     { _id: { $in: ids }, deletedAt: null },

--- a/src/lib/mcp/coursify/tools.js
+++ b/src/lib/mcp/coursify/tools.js
@@ -201,6 +201,7 @@ export function registerCoursifyTools(server) {
         estimatedDuration: z.string().optional(),
         tags: z.array(z.string()).optional(),
         status: z.enum(['draft', 'published']).optional(),
+        isFrozen: z.boolean().optional().describe('Freeze the course to prevent modifications.'),
         authoringStatus: z
           .enum(['idea', 'researching', 'planned', 'drafting', 'reviewing', 'ready', 'published'])
           .optional(),
@@ -221,6 +222,7 @@ export function registerCoursifyTools(server) {
         'estimatedDuration',
         'tags',
         'status',
+        'isFrozen',
       ];
       const PLAN_KEYS = [
         'targetAudience',
@@ -255,6 +257,31 @@ export function registerCoursifyTools(server) {
         return textResult(`Course "${result.course.title}" saved.`, {
           success: true,
           course: result.course,
+        });
+      } catch (err) {
+        return errorResult(err.message);
+      }
+    }
+  );
+
+  server.registerTool(
+    'freeze_course',
+    {
+      title: 'Freeze or Unfreeze Course',
+      description: 'Explicitly lock or unlock a course to prevent or allow modifications.',
+      annotations: MUTATION_ANNOTATIONS,
+      inputSchema: {
+        id: z.string().describe('MongoDB _id of the course'),
+        frozen: z.boolean().describe('True to freeze, false to unfreeze.'),
+      },
+      _meta: toolMeta('Toggling freeze state...', 'Freeze state updated.'),
+    },
+    async ({ id, frozen }) => {
+      try {
+        const result = await dbUpdateCourse({ id, isFrozen: frozen });
+        return textResult(`Course "${result.course.title}" is now ${frozen ? 'frozen' : 'unfrozen'}.`, {
+          success: true,
+          isFrozen: result.course.isFrozen,
         });
       } catch (err) {
         return errorResult(err.message);

--- a/src/lib/mcp/coursify/utils.js
+++ b/src/lib/mcp/coursify/utils.js
@@ -289,6 +289,7 @@ export function normalizeCourse(course) {
       accessedAt: n.accessedAt || null,
     })),
     authoringStatus: course.authoringStatus || 'idea',
+    isFrozen: !!course.isFrozen,
     createdAt: course.createdAt,
     updatedAt: course.updatedAt,
   };

--- a/src/models/CoursifyCourse.js
+++ b/src/models/CoursifyCourse.js
@@ -74,6 +74,10 @@ const CoursifyCourseSchema = new mongoose.Schema(
       enum: ['idea', 'researching', 'planned', 'drafting', 'reviewing', 'ready', 'published'],
       default: 'idea',
     },
+    isFrozen: {
+      type: Boolean,
+      default: false,
+    },
     // ────────────────────────────────────────────────────────────
     deletedAt: {
       type: Date,


### PR DESCRIPTION
This change introduces a mechanism to "freeze" Coursify courses, making them read-only for both AI agents and administrators.

### Core Changes:
- **Data Model**: Added `isFrozen: boolean` to `CoursifyCourse.js`.
- **Business Logic**: Created `ensureNotFrozen` helper in `db-ops.js` and integrated it into all course, module, and section mutation functions.
- **MCP Integration**: New `freeze_course` tool; updated `upsert_course` schema and `get_course` output via `normalizeCourse`.
- **API**: Updated `PATCH /api/coursify/courses/[id]` to permit `isFrozen` updates.
- **Studio UI**: 
    - Added a blue "Frozen" badge in `AuthoringHeader`.
    - Disabled "Publish" button and "Edit" mode features (thumbnail upload, section editing/deletion) in `ModuleSectionList`.
    - Disabled planning field inputs and research note management in `PlanningWorkspace`.
- **CLI Tool**: Added `node .agent/skills/coursify-studio/scripts/coursify.js courses freeze|unfreeze <id>` commands and updated `list`/`get` output.

These changes ensure that production-ready content can be safely locked against accidental modifications.

Fixes #166

---
*PR created automatically by Jules for task [15075573360923261161](https://jules.google.com/task/15075573360923261161) started by @hasanraiyan*