### PR TITLE
Modularize CLI Command Structure (Refactor content.js)

### DIFF
--- a/packages/coursify-cli/src/commands/courses.js
+++ b/packages/coursify-cli/src/commands/courses.js
@@ -3,18 +3,9 @@ import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
 import { apiClient } from '../http-client.js';
-import { parseMarkdownToBlocks, lintContent } from '../utils.js';
+import { parseFile } from '../utils.js';
 
-function parseFile(filePath) {
-  const content = fs.readFileSync(path.resolve(process.cwd(), filePath), 'utf8');
-  if (filePath.endsWith('.yaml') || filePath.endsWith('.yml')) {
-    return yaml.load(content);
-  }
-  return JSON.parse(content);
-}
-
-export function setupContentCommands(program) {
-  // --- Courses ---
+export function setupCoursesCommands(program) {
   const courses = program
     .command('courses')
     .description('Manage course metadata, planning, and research');
@@ -169,9 +160,6 @@ export function setupContentCommands(program) {
           ],
         };
 
-        // Note: The API should ideally push to the array.
-        // For now, we fetch current and append or handle in the backend PATCH.
-        // Assuming backend handles array merge for researchNotes
         await apiClient(`/api/coursify/courses/${id}`, {
           method: 'PATCH',
           body: JSON.stringify(payload),
@@ -252,74 +240,6 @@ export function setupContentCommands(program) {
       try {
         await apiClient(`/api/coursify/courses/${id}`, { method: 'DELETE' });
         console.log(chalk.green(`Course ${id} deleted successfully.`));
-      } catch (error) {
-        console.error(chalk.red(`Error: ${error.message}`));
-      }
-    });
-
-  // --- Modules ---
-  const modules = program
-    .command('modules')
-    .description('Manage course modules and structural hierarchy');
-
-  modules
-    .command('create')
-    .description('Create a new module within a specific course')
-    .requiredOption('-c, --course-id <id>', 'Course ID')
-    .requiredOption('-t, --title <title>', 'Module title')
-    .action(async (options) => {
-      try {
-        const data = await apiClient(`/api/coursify/courses/${options.courseId}/modules`, {
-          method: 'POST',
-          body: JSON.stringify({ title: options.title }),
-        });
-        console.log(chalk.green(`Module created: ${data.module._id}`));
-      } catch (error) {
-        console.error(chalk.red(`Error: ${error.message}`));
-      }
-    });
-
-  // --- Sections ---
-  const sections = program
-    .command('sections')
-    .description('Manage course sections and content synchronization');
-
-  sections
-    .command('sync')
-    .description('Batch synchronize sections from a local directory of Markdown files')
-    .requiredOption('-c, --course-id <id>', 'Course ID')
-    .option('-m, --module-id <id>', 'Module ID')
-    .requiredOption('-d, --dir <path>', 'Directory containing .md files')
-    .action(async (options) => {
-      try {
-        const dirPath = path.resolve(process.cwd(), options.dir);
-        const files = fs
-          .readdirSync(dirPath)
-          .filter((f) => f.endsWith('.md'))
-          .sort();
-
-        for (const file of files) {
-          const content = fs.readFileSync(path.join(dirPath, file), 'utf8');
-          const title = file.replace(/^\d+-/, '').replace('.md', '').replace(/-/g, ' ');
-
-          const issues = lintContent(file, content);
-          if (issues.length > 0) {
-            console.warn(chalk.yellow(`Warning: Issues in ${file}:`));
-            issues.forEach((i) => console.warn(`- ${i}`));
-          }
-
-          const blocks = parseMarkdownToBlocks(content);
-
-          await apiClient(`/api/coursify/courses/${options.courseId}/sections`, {
-            method: 'POST',
-            body: JSON.stringify({
-              title,
-              blocks,
-              moduleId: options.moduleId,
-            }),
-          });
-          console.log(chalk.green(`Synced: ${file}`));
-        }
       } catch (error) {
         console.error(chalk.red(`Error: ${error.message}`));
       }

--- a/packages/coursify-cli/src/commands/modules.js
+++ b/packages/coursify-cli/src/commands/modules.js
@@ -1,0 +1,25 @@
+import chalk from 'chalk';
+import { apiClient } from '../http-client.js';
+
+export function setupModulesCommands(program) {
+  const modules = program
+    .command('modules')
+    .description('Manage course modules and structural hierarchy');
+
+  modules
+    .command('create')
+    .description('Create a new module within a specific course')
+    .requiredOption('-c, --course-id <id>', 'Course ID')
+    .requiredOption('-t, --title <title>', 'Module title')
+    .action(async (options) => {
+      try {
+        const data = await apiClient(`/api/coursify/courses/${options.courseId}/modules`, {
+          method: 'POST',
+          body: JSON.stringify({ title: options.title }),
+        });
+        console.log(chalk.green(`Module created: ${data.module._id}`));
+      } catch (error) {
+        console.error(chalk.red(`Error: ${error.message}`));
+      }
+    });
+}

--- a/packages/coursify-cli/src/commands/sections.js
+++ b/packages/coursify-cli/src/commands/sections.js
@@ -1,0 +1,52 @@
+import chalk from 'chalk';
+import fs from 'fs';
+import path from 'path';
+import { apiClient } from '../http-client.js';
+import { parseMarkdownToBlocks, lintContent } from '../utils.js';
+
+export function setupSectionsCommands(program) {
+  const sections = program
+    .command('sections')
+    .description('Manage course sections and content synchronization');
+
+  sections
+    .command('sync')
+    .description('Batch synchronize sections from a local directory of Markdown files')
+    .requiredOption('-c, --course-id <id>', 'Course ID')
+    .option('-m, --module-id <id>', 'Module ID')
+    .requiredOption('-d, --dir <path>', 'Directory containing .md files')
+    .action(async (options) => {
+      try {
+        const dirPath = path.resolve(process.cwd(), options.dir);
+        const files = fs
+          .readdirSync(dirPath)
+          .filter((f) => f.endsWith('.md'))
+          .sort();
+
+        for (const file of files) {
+          const content = fs.readFileSync(path.join(dirPath, file), 'utf8');
+          const title = file.replace(/^\d+-/, '').replace('.md', '').replace(/-/g, ' ');
+
+          const issues = lintContent(file, content);
+          if (issues.length > 0) {
+            console.warn(chalk.yellow(`Warning: Issues in ${file}:`));
+            issues.forEach((i) => console.warn(`- ${i}`));
+          }
+
+          const blocks = parseMarkdownToBlocks(content);
+
+          await apiClient(`/api/coursify/courses/${options.courseId}/sections`, {
+            method: 'POST',
+            body: JSON.stringify({
+              title,
+              blocks,
+              moduleId: options.moduleId,
+            }),
+          });
+          console.log(chalk.green(`Synced: ${file}`));
+        }
+      } catch (error) {
+        console.error(chalk.red(`Error: ${error.message}`));
+      }
+    });
+}

--- a/packages/coursify-cli/src/index.js
+++ b/packages/coursify-cli/src/index.js
@@ -4,7 +4,9 @@ import { program } from 'commander';
 import chalk from 'chalk';
 import boxen from 'boxen';
 import { setupAuthCommands } from './commands/auth.js';
-import { setupContentCommands } from './commands/content.js';
+import { setupCoursesCommands } from './commands/courses.js';
+import { setupModulesCommands } from './commands/modules.js';
+import { setupSectionsCommands } from './commands/sections.js';
 import { setupUtilsCommands } from './commands/utils.js';
 import { setupConfigCommands } from './commands/config.js';
 
@@ -26,7 +28,9 @@ program
   });
 
 setupAuthCommands(program);
-setupContentCommands(program);
+setupCoursesCommands(program);
+setupModulesCommands(program);
+setupSectionsCommands(program);
 setupUtilsCommands(program);
 setupConfigCommands(program);
 

--- a/packages/coursify-cli/src/utils.js
+++ b/packages/coursify-cli/src/utils.js
@@ -1,6 +1,18 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
 /**
  * Ported from src/lib/mcp/coursify/utils.js
  */
+
+export function parseFile(filePath) {
+  const content = fs.readFileSync(path.resolve(process.cwd(), filePath), 'utf8');
+  if (filePath.endsWith('.yaml') || filePath.endsWith('.yml')) {
+    return yaml.load(content);
+  }
+  return JSON.parse(content);
+}
 
 export function unescapeString(str) {
   if (!str) return '';


### PR DESCRIPTION
The `packages/coursify-cli/src/commands/content.js` file was a monolithic "God Object" managing Courses, Modules, and Sections. This refactoring splits it into three dedicated files:
- `src/commands/courses.js`: Course CRUD, planning, and research.
- `src/commands/modules.js`: Module creation and management.
- `src/commands/sections.js`: Section synchronization and content management.

Shared logic like `parseFile` was moved to `src/utils.js`. The main entry point `src/index.js` was updated to reflect these changes. Feature parity and command syntax are maintained.

Fixes #170

---
*PR created automatically by Jules for task [7471056697236842820](https://jules.google.com/task/7471056697236842820) started by @hasanraiyan*