### PR TITLE
fix(coursify): use generated markdown for TOC when content is absent

### DIFF
--- a/src/components/coursify/reader/CourseReaderShell.js
+++ b/src/components/coursify/reader/CourseReaderShell.js
@@ -1,7 +1,7 @@
 'use client';
 import { generateMarkdownFromBlocks } from '@/utils/coursify-parser';
 
-import { useRef } from 'react';
+import { useRef, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { BookOpen } from 'lucide-react';
 import { useTableOfContents } from '@/hooks/coursify/useTableOfContents';
@@ -37,12 +37,14 @@ export function CourseReaderShell({ initialData, slug, activeSectionId }) {
   const currentSection = sections.find((s) => s._id === activeSection);
   const isSectionLoaded = !!(currentSection?.content || currentSection?.blocks?.length > 0);
 
-  const { headings, activeHeading } = useTableOfContents(
-    currentSection?.content ||
-      (currentSection?.blocks ? generateMarkdownFromBlocks(currentSection.blocks) : ''),
-    contentRef,
-    mainRef
-  );
+  const tocMarkdown = useMemo(() => {
+    if (currentSection?.content) return currentSection.content;
+    if (currentSection?.blocks?.length > 0)
+      return generateMarkdownFromBlocks(currentSection.blocks);
+    return '';
+  }, [currentSection?.content, currentSection?.blocks]);
+
+  const { headings, activeHeading } = useTableOfContents(tocMarkdown, contentRef, mainRef);
 
   const {
     sidebarOpen,

--- a/src/components/coursify/reader/CourseReaderShell.js
+++ b/src/components/coursify/reader/CourseReaderShell.js
@@ -1,4 +1,5 @@
 'use client';
+import { generateMarkdownFromBlocks } from '@/utils/coursify-parser';
 
 import { useRef } from 'react';
 import { useRouter } from 'next/navigation';
@@ -37,7 +38,8 @@ export function CourseReaderShell({ initialData, slug, activeSectionId }) {
   const isSectionLoaded = !!(currentSection?.content || currentSection?.blocks?.length > 0);
 
   const { headings, activeHeading } = useTableOfContents(
-    currentSection?.content || '',
+    currentSection?.content ||
+      (currentSection?.blocks ? generateMarkdownFromBlocks(currentSection.blocks) : ''),
     contentRef,
     mainRef
   );


### PR DESCRIPTION
When creating sections in the new architecture, \`content\` may be null or empty if the section content is only stored in \`blocks\`. This caused the table of contents hook (\`useTableOfContents\`) to fail to extract any headers, leading to an empty table of contents side navigation. 

To fix this, \`generateMarkdownFromBlocks\` was imported and used to generate the markdown content structure to be parsed correctly by the TOC extractor whenever \`content\` is absent but \`blocks\` is available.

---
*PR created automatically by Jules for task [6064868117021504945](https://jules.google.com/task/6064868117021504945) started by @hasanraiyan*