### PR TITLE
Add ChartBlock magic block to Coursify

### DIFF
--- a/.agent/skills/coursify-studio/SKILL.md
+++ b/.agent/skills/coursify-studio/SKILL.md
@@ -180,6 +180,7 @@ When you create a section with `coursify init-section`, it generates a template 
 - `[AccordionBlock]` — for FAQs and collapsible details
 - `[TabsBlock]` — for multi-language examples or alternative approaches
 - `[CalloutBlock]` — for warnings, tips, and important notes
+- `[ChartBlock]` — for interactive data visualizations
 - `[QuizBlock]` — for assessment
 
 Edit the template to keep only the blocks you need for that section, and customize the content.
@@ -333,6 +334,28 @@ content: "Do not mutate state directly in React!"
 **Best practices:**
 - Valid types: `info`, `tip`, `warning`, `danger`
 - Use sparingly so they maintain their impact
+
+#### ChartBlock
+
+Interactive data visualization using Chart.js.
+
+```markdown
+## [ChartBlock]
+
+type: "bar"
+title: "Performance Comparison"
+data:
+  labels: ["A", "B", "C"]
+  datasets:
+    - label: "Speed"
+      data: [100, 200, 150]
+      color: "#1f644e"
+```
+
+**Best practices:**
+- Supported types: `bar`, `line`, `pie`, `doughnut`, `polarArea`, `radar`, `scatter`, `bubble`
+- Labels count must match data points count
+- Use colors that are high-contrast and accessible
 
 #### VideoBlock
 Embed external videos (YouTube, Vimeo, etc.)

--- a/.agent/skills/coursify-studio/references/demo-data.md
+++ b/.agent/skills/coursify-studio/references/demo-data.md
@@ -132,6 +132,25 @@ content: "Remember to use `lazy_load()` for files over 100MB to avoid Out-Of-Mem
 
 ---
 
+## [ChartBlock]
+
+type: "bar"
+title: "Loader Market Share"
+description: "Usage frequency of standard document loaders in RAG pipelines"
+
+data:
+  labels: ["PDF", "Notion", "GitHub", "Postgres", "Web Search"]
+  datasets:
+    - label: "Production Usage"
+      data: [85, 42, 38, 25, 60]
+      color: "#1f644e"
+
+options:
+  showLegend: true
+  beginAtZero: true
+
+---
+
 ## [ResourceBlock]
 
 url: https://python.langchain.com/docs/integrations/document_loaders/

--- a/.agent/skills/coursify-studio/references/schemas.md
+++ b/.agent/skills/coursify-studio/references/schemas.md
@@ -560,6 +560,72 @@ type: "doc"
 
 ---
 
+### ChartBlock
+
+Interactive data visualization using Chart.js.
+
+```markdown
+## [ChartBlock]
+
+type: "bar"
+title: "Chart Title"
+description: "Optional description"
+
+data:
+  labels: ["Jan", "Feb", "Mar"]
+  datasets:
+    - label: "Series A"
+      data: [10, 20, 30]
+      color: "#1f644e"
+    - label: "Series B"
+      data: [15, 25, 35]
+
+options:
+  showLegend: true
+  showGrid: true
+  stacked: false
+  beginAtZero: true
+```
+
+**Schema:**
+
+```json
+{
+  "type": "ChartBlock",
+  "chart": {
+    "type": "bar",
+    "title": "Chart Title",
+    "description": "Optional description",
+    "data": {
+      "labels": ["Jan", "Feb", "Mar"],
+      "datasets": [
+        {
+          "label": "Series A",
+          "data": [10, 20, 30],
+          "color": "#1f644e"
+        }
+      ]
+    },
+    "options": {
+      "showLegend": true,
+      "showGrid": true,
+      "stacked": false,
+      "beginAtZero": true
+    }
+  }
+}
+```
+
+**Supported Types:**
+- `bar`, `line`, `pie`, `doughnut`, `polarArea`, `radar`, `scatter`, `bubble`
+
+**Requirements:**
+- `labels` must match the length of `data` arrays in datasets
+- `color` is optional (auto-assigned if omitted)
+- `options` are passed through to Chart.js
+
+---
+
 ## ResearchNote Schema
 
 Tracks sources and findings during the research phase.

--- a/packages/coursify-cli/bin/coursify.js
+++ b/packages/coursify-cli/bin/coursify.js
@@ -18,7 +18,7 @@ import {
 
 const program = new Command();
 
-program.name('coursify').description('Local-first authoring tool for Coursify').version('1.1.4');
+program.name('coursify').description('Local-first authoring tool for Coursify').version('1.1.5');
 
 program.option('-v, --verbose', 'Enable verbose logging', false);
 

--- a/packages/coursify-cli/package.json
+++ b/packages/coursify-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coursify/cli",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Local-first authoring tool for the Coursify platform",
   "author": "Raiyan Hasan <raiyanhasa2006@gmail.com>",
   "license": "MIT",

--- a/packages/coursify-cli/src/scaffold.js
+++ b/packages/coursify-cli/src/scaffold.js
@@ -57,6 +57,17 @@ title: "Common Questions"
   correctAnswer: "Option A"
   explanation: "Option A is correct because..."
 
+## [ChartBlock]
+type: "bar"
+title: "Sample Data"
+description: "Visualization of growth"
+data:
+  labels: ["Q1", "Q2", "Q3", "Q4"]
+  datasets:
+    - label: "Revenue"
+      data: [450, 520, 610, 800]
+      color: "#1f644e"
+
 ## [MdBlock]
 ### Additional Resources
 Link to external resources, documentation, or references here.

--- a/packages/coursify-cli/src/validator.js
+++ b/packages/coursify-cli/src/validator.js
@@ -137,6 +137,7 @@ export async function validateCourse(dir) {
             'AccordionBlock',
             'TabsBlock',
             'CalloutBlock',
+            'ChartBlock',
           ];
           const AUTHORING_ALIASES = ['MermaidBlock', 'CodeBlock'];
           const VALID_BLOCKS = [...SUPPORTED_BLOCKS, ...AUTHORING_ALIASES];
@@ -214,6 +215,24 @@ export async function validateCourse(dir) {
                 `MermaidBlock might have invalid syntax (no recognized diagram type): ${modDirEntry.name}/${secDirEntry.name}`
               );
             }
+          }
+
+          // ChartBlock Validation
+          if (foundBlocks.includes('ChartBlock')) {
+            const chartParts = content.split(/##\s+\[ChartBlock\]/).slice(1);
+            chartParts.forEach((part) => {
+              const chartContent = part.split(/##\s+\[/)[0];
+              if (!chartContent.includes('labels:')) {
+              results.errors.push(
+                `ChartBlock missing labels in ${modDirEntry.name}/${secDirEntry.name}`
+              );
+            }
+            if (!chartContent.includes('datasets:')) {
+              results.errors.push(
+                `ChartBlock missing datasets in ${modDirEntry.name}/${secDirEntry.name}`
+              );
+            }
+            });
           }
         } catch (e) {
           results.errors.push(

--- a/src/components/coursify/EditSectionModal.js
+++ b/src/components/coursify/EditSectionModal.js
@@ -16,6 +16,8 @@ import {
   ChevronRight,
   FolderOpen,
   AlertCircle,
+  BarChart3,
+  Settings,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import QuizEditor from './QuizEditor';
@@ -33,6 +35,7 @@ const BLOCK_TYPES = [
   { type: 'ResourceBlock', label: 'Resource', icon: FileText },
   { type: 'TabsBlock', label: 'Tabs', icon: FolderOpen },
   { type: 'CalloutBlock', label: 'Callout', icon: AlertCircle },
+  { type: 'ChartBlock', label: 'Chart', icon: BarChart3 },
 ];
 
 function QuickAdder({ isOpen, onToggle, onAdd }) {
@@ -164,6 +167,18 @@ export default function EditSectionModal({ section, onSave, onClose }) {
       newBlock.calloutType = 'info';
       newBlock.title = '';
       newBlock.content = '';
+    }
+    if (type === 'ChartBlock') {
+      newBlock.chart = {
+        type: 'bar',
+        title: '',
+        description: '',
+        data: {
+          labels: ['Jan', 'Feb', 'Mar'],
+          datasets: [{ label: 'Series 1', data: [10, 20, 15] }],
+        },
+        options: { showLegend: true, showGrid: true },
+      };
     }
 
     setBlocks((prev) => {
@@ -613,6 +628,224 @@ export default function EditSectionModal({ section, onSave, onClose }) {
                             placeholder="Callout Content (Markdown Support)"
                             className="w-full h-24 px-3 py-2 rounded-xl border border-[#e5e3d8] text-xs bg-[#fcfbf5] resize-y focus:border-[#1f644e] outline-none"
                           />
+                        </div>
+                      )}
+                      {block.type === 'ChartBlock' && (
+                        <div className="space-y-4">
+                          <div className="grid grid-cols-2 gap-4">
+                            <div className="space-y-1.5">
+                              <label className="text-[10px] font-bold uppercase text-[#7c8e88] px-1">
+                                Chart Type
+                              </label>
+                              <select
+                                value={block.chart?.type || 'bar'}
+                                onChange={(e) =>
+                                  updateBlock(i, 'chart', { ...block.chart, type: e.target.value })
+                                }
+                                className="w-full px-4 py-2.5 rounded-xl border border-[#e5e3d8] bg-white text-sm font-bold capitalize outline-none focus:border-[#1f644e]"
+                              >
+                                {[
+                                  'bar',
+                                  'line',
+                                  'pie',
+                                  'doughnut',
+                                  'polarArea',
+                                  'radar',
+                                  'scatter',
+                                  'bubble',
+                                ].map((t) => (
+                                  <option key={t} value={t}>
+                                    {t}
+                                  </option>
+                                ))}
+                              </select>
+                            </div>
+                            <div className="space-y-1.5">
+                              <label className="text-[10px] font-bold uppercase text-[#7c8e88] px-1">
+                                Title
+                              </label>
+                              <input
+                                value={block.chart?.title || ''}
+                                onChange={(e) =>
+                                  updateBlock(i, 'chart', { ...block.chart, title: e.target.value })
+                                }
+                                placeholder="Chart Title"
+                                className="w-full px-4 py-2.5 rounded-xl border border-[#e5e3d8] bg-white text-sm font-bold outline-none focus:border-[#1f644e]"
+                              />
+                            </div>
+                          </div>
+
+                          <input
+                            value={block.chart?.description || ''}
+                            onChange={(e) =>
+                              updateBlock(i, 'chart', {
+                                ...block.chart,
+                                description: e.target.value,
+                              })
+                            }
+                            placeholder="Description"
+                            className="w-full px-4 py-2.5 rounded-xl border border-[#e5e3d8] bg-[#fcfbf5] text-sm outline-none focus:border-[#1f644e]"
+                          />
+
+                          <div className="p-4 rounded-2xl bg-[#fcfbf5] border border-[#e5e3d8] space-y-4">
+                            <div className="flex items-center justify-between">
+                              <span className="text-[10px] font-bold uppercase text-[#7c8e88] tracking-wider">
+                                Data & Labels
+                              </span>
+                              <div className="text-[10px] text-[#7c8e88]">
+                                Labels (comma separated)
+                              </div>
+                            </div>
+                            <input
+                              value={(block.chart?.data?.labels || []).join(', ')}
+                              onChange={(e) => {
+                                const labels = e.target.value.split(',').map((l) => l.trim());
+                                updateBlock(i, 'chart', {
+                                  ...block.chart,
+                                  data: { ...block.chart.data, labels },
+                                });
+                              }}
+                              placeholder="e.g. Jan, Feb, Mar"
+                              className="w-full px-4 py-2.5 rounded-xl border border-[#e5e3d8] bg-white text-sm outline-none focus:border-[#1f644e]"
+                            />
+
+                            <div className="space-y-3">
+                              {(block.chart?.data?.datasets || []).map((ds, dsi) => (
+                                <div
+                                  key={dsi}
+                                  className="p-3 rounded-xl bg-white border border-[#e5e3d8] space-y-3"
+                                >
+                                  <div className="flex items-center gap-2">
+                                    <input
+                                      value={ds.label}
+                                      onChange={(e) => {
+                                        const datasets = block.chart.data.datasets.map((d, idx) =>
+                                          idx === dsi ? { ...d, label: e.target.value } : d
+                                        );
+                                        updateBlock(i, 'chart', {
+                                          ...block.chart,
+                                          data: { ...block.chart.data, datasets },
+                                        });
+                                      }}
+                                      placeholder="Dataset Label"
+                                      className="flex-1 px-3 py-1.5 rounded-lg border border-[#e5e3d8] text-xs font-bold outline-none focus:border-[#1f644e]"
+                                    />
+                                    <input
+                                      type="color"
+                                      value={ds.color || '#1f644e'}
+                                      onChange={(e) => {
+                                        const datasets = block.chart.data.datasets.map((d, idx) =>
+                                          idx === dsi ? { ...d, color: e.target.value } : d
+                                        );
+                                        updateBlock(i, 'chart', {
+                                          ...block.chart,
+                                          data: { ...block.chart.data, datasets },
+                                        });
+                                      }}
+                                      className="w-8 h-8 rounded-lg overflow-hidden border-none"
+                                    />
+                                    <button
+                                      onClick={() => {
+                                        const datasets = block.chart.data.datasets.filter(
+                                          (_, idx) => idx !== dsi
+                                        );
+                                        updateBlock(i, 'chart', {
+                                          ...block.chart,
+                                          data: { ...block.chart.data, datasets },
+                                        });
+                                      }}
+                                      className="p-1.5 text-[#7c8e88] hover:text-[#c94c4c]"
+                                    >
+                                      <Trash2 className="w-3.5 h-3.5" />
+                                    </button>
+                                  </div>
+                                  <input
+                                    value={(ds.data || []).join(', ')}
+                                    onChange={(e) => {
+                                      const data = e.target.value
+                                        .split(',')
+                                        .map((v) => parseFloat(v.trim()))
+                                        .filter((v) => !isNaN(v));
+                                      const datasets = block.chart.data.datasets.map((d, idx) =>
+                                        idx === dsi ? { ...d, data } : d
+                                      );
+                                      updateBlock(i, 'chart', {
+                                        ...block.chart,
+                                        data: { ...block.chart.data, datasets },
+                                      });
+                                    }}
+                                    placeholder="Data points (e.g. 10, 20, 30)"
+                                    className="w-full px-3 py-1.5 rounded-lg border border-[#e5e3d8] text-xs outline-none focus:border-[#1f644e]"
+                                  />
+                                </div>
+                              ))}
+                              <button
+                                onClick={() => {
+                                  const datasets = [
+                                    ...(block.chart.data.datasets || []),
+                                    { label: '', data: [], color: '' },
+                                  ];
+                                  updateBlock(i, 'chart', {
+                                    ...block.chart,
+                                    data: { ...block.chart.data, datasets },
+                                  });
+                                }}
+                                className="w-full py-2 rounded-lg border border-dashed border-[#e5e3d8] text-[10px] font-bold text-[#7c8e88] hover:border-[#1f644e] hover:text-[#1f644e] transition-colors"
+                              >
+                                + Add Dataset
+                              </button>
+                            </div>
+                          </div>
+
+                          <div className="flex items-center gap-4 px-1">
+                            <div className="flex items-center gap-2">
+                              <input
+                                type="checkbox"
+                                checked={block.chart?.options?.showLegend !== false}
+                                onChange={(e) =>
+                                  updateBlock(i, 'chart', {
+                                    ...block.chart,
+                                    options: {
+                                      ...block.chart.options,
+                                      showLegend: e.target.checked,
+                                    },
+                                  })
+                                }
+                                className="w-4 h-4 rounded border-[#e5e3d8] text-[#1f644e] focus:ring-[#1f644e]"
+                              />
+                              <span className="text-xs font-medium text-[#1e3a34]">
+                                Show Legend
+                              </span>
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <input
+                                type="checkbox"
+                                checked={block.chart?.options?.showGrid !== false}
+                                onChange={(e) =>
+                                  updateBlock(i, 'chart', {
+                                    ...block.chart,
+                                    options: { ...block.chart.options, showGrid: e.target.checked },
+                                  })
+                                }
+                                className="w-4 h-4 rounded border-[#e5e3d8] text-[#1f644e] focus:ring-[#1f644e]"
+                              />
+                              <span className="text-xs font-medium text-[#1e3a34]">Show Grid</span>
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <input
+                                type="checkbox"
+                                checked={block.chart?.options?.stacked === true}
+                                onChange={(e) =>
+                                  updateBlock(i, 'chart', {
+                                    ...block.chart,
+                                    options: { ...block.chart.options, stacked: e.target.checked },
+                                  })
+                                }
+                                className="w-4 h-4 rounded border-[#e5e3d8] text-[#1f644e] focus:ring-[#1f644e]"
+                              />
+                              <span className="text-xs font-medium text-[#1e3a34]">Stacked</span>
+                            </div>
+                          </div>
                         </div>
                       )}
                     </div>

--- a/src/components/coursify/reader/ChartBlock.js
+++ b/src/components/coursify/reader/ChartBlock.js
@@ -1,0 +1,213 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import dynamic from 'next/dynamic';
+import { motion } from 'framer-motion';
+import { BarChart3, Info, AlertCircle } from 'lucide-react';
+
+// Dynamic loader for Chart.js components
+const ChartComponent = dynamic(
+  async () => {
+    const {
+      Chart: ChartJS,
+      CategoryScale,
+      LinearScale,
+      BarElement,
+      LineElement,
+      PointElement,
+      ArcElement,
+      RadialLinearScale,
+      BarController,
+      LineController,
+      PieController,
+      DoughnutController,
+      PolarAreaController,
+      RadarController,
+      ScatterController,
+      BubbleController,
+      Title,
+      Tooltip,
+      Legend,
+      Filler,
+    } = await import('chart.js');
+    const { Bar, Line, Pie, Doughnut, PolarArea, Radar, Scatter, Bubble } = await import(
+      'react-chartjs-2'
+    );
+
+    ChartJS.register(
+      CategoryScale,
+      LinearScale,
+      BarElement,
+      LineElement,
+      PointElement,
+      ArcElement,
+      RadialLinearScale,
+      BarController,
+      LineController,
+      PieController,
+      DoughnutController,
+      PolarAreaController,
+      RadarController,
+      ScatterController,
+      BubbleController,
+      Title,
+      Tooltip,
+      Legend,
+      Filler
+    );
+
+    // Return a wrapper that can handle all chart types
+    return function Charts({ type, data, options, style }) {
+      const components = { Bar, Line, Pie, Doughnut, PolarArea, Radar, Scatter, Bubble };
+      const ChartToRender = components[type.charAt(0).toUpperCase() + type.slice(1)] || Bar;
+      return <ChartToRender data={data} options={options} style={style} />;
+    };
+  },
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-64 flex items-center justify-center bg-[#fcfbf5] rounded-2xl animate-pulse text-[#7c8e88] text-sm font-bold">
+        Loading Visualization...
+      </div>
+    ),
+  }
+);
+
+const CHART_COLORS = [
+  '#1f644e', // Coursify Green
+  '#4a90d9', // Blue
+  '#e67e22', // Orange
+  '#9b59b6', // Purple
+  '#e74c3c', // Red
+  '#1abc9c', // Teal
+  '#f1c40f', // Yellow
+  '#34495e', // Navy
+  '#7f8c8d', // Gray
+  '#27ae60', // Emerald
+];
+
+export function ChartBlock({ block }) {
+  const chartData = block.chart;
+
+  // Destructure with safe defaults
+  const {
+    type = 'bar',
+    title,
+    description,
+    data = { labels: [], datasets: [] },
+    options = {},
+  } = chartData || {};
+
+  const processedData = useMemo(() => {
+    if (!data || !data.datasets || !Array.isArray(data.datasets)) return null;
+
+    return {
+      labels: data.labels || [],
+      datasets: data.datasets.map((ds, idx) => ({
+        label: ds.label || `Series ${idx + 1}`,
+        data: ds.data || [],
+        backgroundColor: ds.color || CHART_COLORS[idx % CHART_COLORS.length],
+        borderColor: ds.color || CHART_COLORS[idx % CHART_COLORS.length],
+        borderWidth: type === 'line' || type === 'radar' ? 2 : 1,
+        tension: 0.3,
+        fill: options.fill ?? false,
+      })),
+    };
+  }, [data, type, options.fill]);
+
+  const chartOptions = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          display: options.showLegend !== false,
+          position: 'bottom',
+          labels: {
+            usePointStyle: true,
+            boxWidth: 8,
+            padding: 20,
+            font: { size: 12, weight: 'bold', family: 'inherit' },
+            color: '#1e3a34',
+          },
+        },
+        tooltip: {
+          backgroundColor: '#1e3a34',
+          padding: 12,
+          titleFont: { size: 13, weight: 'bold' },
+          bodyFont: { size: 12 },
+          cornerRadius: 8,
+          displayColors: true,
+        },
+      },
+      scales:
+        type === 'bar' || type === 'line' || type === 'scatter' || type === 'bubble'
+          ? {
+              x: {
+                stacked: options.stacked || false,
+                grid: { display: options.showGrid !== false, color: '#f0f0f0' },
+                ticks: { color: '#7c8e88', font: { size: 11, weight: '600' } },
+              },
+              y: {
+                beginAtZero: options.beginAtZero !== false,
+                stacked: options.stacked || false,
+                grid: { display: options.showGrid !== false, color: '#f0f0f0' },
+                ticks: { color: '#7c8e88', font: { size: 11, weight: '600' } },
+              },
+            }
+          : undefined,
+      indexAxis: options.indexAxis || 'x',
+      ...options,
+    }),
+    [type, options]
+  );
+
+  // Error Placeholder
+  if (!chartData || !data || !data.datasets || data.datasets.length === 0) {
+    return (
+      <div className="my-6 p-8 rounded-3xl border-2 border-dashed border-[#e5e3d8] bg-[#fcfbf5] flex flex-col items-center justify-center text-center">
+        <div className="w-12 h-12 rounded-2xl bg-white flex items-center justify-center shadow-sm mb-4">
+          <AlertCircle className="w-6 h-6 text-[#c94c4c]" />
+        </div>
+        <p className="text-[#1e3a34] font-bold">Invalid Chart Configuration</p>
+        <p className="text-xs text-[#7c8e88] mt-1 max-w-[280px]">
+          Make sure your datasets and labels are properly defined in the editor.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      className="my-8 overflow-hidden rounded-3xl border border-[#e5e3d8] bg-white shadow-sm"
+    >
+      {(title || description) && (
+        <div className="p-6 border-b border-[#fcfbf5] bg-[#fcfbf5]/50">
+          {title && <h3 className="text-lg font-bold text-[#1e3a34]">{title}</h3>}
+          {description && <p className="text-sm text-[#7c8e88] mt-1">{description}</p>}
+        </div>
+      )}
+
+      <div className="p-6">
+        <div className="h-[350px] relative">
+          <ChartComponent
+            type={type}
+            data={processedData}
+            options={chartOptions}
+            style={{ width: '100%', height: '100%' }}
+          />
+        </div>
+      </div>
+
+      {options.footer && (
+        <div className="px-6 py-4 bg-[#fcfbf5]/30 border-t border-[#fcfbf5] flex items-center gap-2">
+          <Info className="w-3.5 h-3.5 text-[#1f644e]" />
+          <span className="text-[11px] font-medium text-[#7c8e88]">{options.footer}</span>
+        </div>
+      )}
+    </motion.div>
+  );
+}

--- a/src/components/coursify/reader/CoursifyBlockRenderer.js
+++ b/src/components/coursify/reader/CoursifyBlockRenderer.js
@@ -8,6 +8,7 @@ import { StepByStepBlock } from './StepByStepBlock';
 import { AccordionBlock } from './AccordionBlock';
 import { TabsBlock } from './TabsBlock';
 import { CalloutBlock } from './CalloutBlock';
+import { ChartBlock } from './ChartBlock';
 import { PlayCircle, ExternalLink, FileText } from 'lucide-react';
 import { parseMarkdownToBlocks } from '@/utils/coursify-parser';
 
@@ -88,6 +89,8 @@ export function CoursifyBlockRenderer({ blocks, content }) {
             return <TabsBlock key={block._id || idx} block={block} />;
           case 'CalloutBlock':
             return <CalloutBlock key={block._id || idx} block={block} />;
+          case 'ChartBlock':
+            return <ChartBlock key={block._id || idx} block={block} />;
           default:
             return null;
         }

--- a/src/config/coursify-blocks.js
+++ b/src/config/coursify-blocks.js
@@ -14,6 +14,7 @@ export const SUPPORTED_BLOCKS = [
   'AccordionBlock',
   'TabsBlock',
   'CalloutBlock',
+  'ChartBlock',
 ];
 
 /**

--- a/src/hooks/coursify/useTableOfContents.js
+++ b/src/hooks/coursify/useTableOfContents.js
@@ -37,7 +37,7 @@ export function useTableOfContents(content, contentRef, scrollContainerRef) {
         // 2. Specialized Block Detection in Headings
         // e.g. ## [QuizBlock] ->Knowledge Check
         const blockMatch = text.match(
-          /^\[(MdBlock|QuizBlock|VideoBlock|ResourceBlock|StepByStepBlock|AccordionBlock|TabsBlock|CalloutBlock)\]/
+          /^\[(MdBlock|QuizBlock|VideoBlock|ResourceBlock|StepByStepBlock|AccordionBlock|TabsBlock|CalloutBlock|ChartBlock)\]/
         );
 
         if (blockMatch) {
@@ -51,6 +51,7 @@ export function useTableOfContents(content, contentRef, scrollContainerRef) {
           else if (type === 'ResourceBlock') text = 'Resource';
           else if (type === 'TabsBlock') text = 'Interactive Example';
           else if (type === 'CalloutBlock') text = 'Important Note';
+          else if (type === 'ChartBlock') text = 'Data Visualization';
           else continue; // Skip generic MdBlock headers in TOC
         }
 

--- a/src/lib/mcp/coursify/utils.js
+++ b/src/lib/mcp/coursify/utils.js
@@ -103,6 +103,7 @@ export function normalizeSection(section) {
       items: b.items,
       tabs: b.tabs,
       calloutType: b.calloutType,
+      chart: b.chart,
       order: b.order ?? 0,
     })),
     summary: section.summary || '',

--- a/src/utils/coursify-parser.js
+++ b/src/utils/coursify-parser.js
@@ -34,6 +34,7 @@ export function parseMarkdownToBlocks(text) {
     'AccordionBlock',
     'TabsBlock',
     'CalloutBlock',
+    'ChartBlock',
   ];
   const AUTHORING_ALIASES = {
     MermaidBlock: { target: 'MdBlock', wrap: (c) => `\`\`\`mermaid\n${c}\n\`\`\`` },
@@ -259,6 +260,81 @@ export function parseMarkdownToBlocks(text) {
         }
         if (qObj.question) block.quiz.questions.push(qObj);
       }
+    } else if (m.type === 'ChartBlock') {
+      block.chart = {
+        type: 'bar',
+        title: '',
+        description: '',
+        data: { labels: [], datasets: [] },
+        options: {},
+      };
+
+      const typeMatch = rawContent.match(/^type:\s*["']?(.*?)["']?$/m);
+      if (typeMatch) block.chart.type = unescapeString(typeMatch[1]);
+
+      const titleMatch = rawContent.match(/^title:\s*["']?(.*?)["']?$/m);
+      if (titleMatch) block.chart.title = unescapeString(titleMatch[1]);
+
+      const descMatch = rawContent.match(/^description:\s*["']?(.*?)["']?$/m);
+      if (descMatch) block.chart.description = unescapeString(descMatch[1]);
+
+      // Extract data section
+      const dataSectionMatch = rawContent.match(/data:\s*\n([\s\S]*?)(?:\n\w+:|$)/);
+      if (dataSectionMatch) {
+        const dataContent = dataSectionMatch[1];
+        const labelsMatch = dataContent.match(/labels:\s*\[(.*?)\]/);
+        if (labelsMatch) {
+          block.chart.data.labels = labelsMatch[1].split(',').map((l) => unescapeString(l.trim()));
+        }
+
+        const datasetsContentMatch = dataContent.match(/datasets:\s*\n([\s\S]*)$/);
+        const datasetsContent = datasetsContentMatch ? datasetsContentMatch[1] : dataContent;
+
+        const datasetsParts = datasetsContent
+          .split(/(?:^|\n)\s*-\s*label:\s*/)
+          .filter((p) => p.trim());
+        datasetsParts.forEach((part) => {
+          const lines = part.split('\n');
+          const label = unescapeString(lines[0].trim());
+          const dataset = { label, data: [], color: '' };
+
+          const dataMatch = part.match(/data:\s*\[(.*?)\]/);
+          if (dataMatch) {
+            dataset.data = dataMatch[1]
+              .split(',')
+              .map((d) => parseFloat(d.trim()))
+              .filter((d) => !isNaN(d));
+          }
+
+          const colorMatch = part.match(/color:\s*["']?(.*?)["']?$/m);
+          if (colorMatch) {
+            dataset.color = unescapeString(colorMatch[1]);
+          }
+
+          block.chart.data.datasets.push(dataset);
+        });
+      }
+
+      // Extract options section
+      const optionsSectionMatch = rawContent.match(/options:\s*\n([\s\S]*?)(?:\n\w+:|$)/);
+      if (optionsSectionMatch) {
+        const optionsContent = optionsSectionMatch[1];
+        const optionLines = optionsContent.split('\n');
+        optionLines.forEach((line) => {
+          const trimmed = line.trim();
+          if (!trimmed || trimmed.startsWith('-')) return;
+          const [key, ...valParts] = trimmed.split(':');
+          if (key && valParts.length > 0) {
+            const val = valParts.join(':').trim();
+            const cleanVal = unescapeString(val);
+            if (cleanVal === 'true') block.chart.options[key.trim()] = true;
+            else if (cleanVal === 'false') block.chart.options[key.trim()] = false;
+            else if (!isNaN(cleanVal) && cleanVal !== '')
+              block.chart.options[key.trim()] = parseFloat(cleanVal);
+            else block.chart.options[key.trim()] = cleanVal;
+          }
+        });
+      }
     }
     blocks.push(block);
   }
@@ -326,6 +402,28 @@ export function generateMarkdownFromBlocks(blocks) {
         output += `  explanation: "${q.explanation}"\n`;
         output += `  points: ${q.points}\n`;
       });
+      output += '\n';
+    } else if (block.type === 'ChartBlock' && block.chart) {
+      const c = block.chart;
+      output += `type: "${c.type || 'bar'}"\n`;
+      if (c.title) output += `title: "${c.title}"\n`;
+      if (c.description) output += `description: "${c.description}"\n`;
+
+      output += `data:\n`;
+      output += `  labels: [${(c.data?.labels || []).map((l) => `"${l}"`).join(', ')}]\n`;
+      output += `  datasets:\n`;
+      (c.data?.datasets || []).forEach((ds) => {
+        output += `    - label: "${ds.label}"\n`;
+        output += `      data: [${(ds.data || []).join(', ')}]\n`;
+        if (ds.color) output += `      color: "${ds.color}"\n`;
+      });
+
+      if (c.options && Object.keys(c.options).length > 0) {
+        output += `options:\n`;
+        Object.entries(c.options).forEach(([k, v]) => {
+          output += `  ${k}: ${typeof v === 'string' ? `"${v}"` : v}\n`;
+        });
+      }
       output += '\n';
     }
     if (i < blocks.length - 1) output += '---\n\n';


### PR DESCRIPTION
Added a new `ChartBlock` magic block to Coursify. This feature allows authors to create interactive charts (bar, line, pie, etc.) directly from Markdown using a simple YAML-like syntax. The implementation includes a full visual editor in the Studio, a high-performance reader component using dynamic imports for SSR safety, and updated CLI tooling for local-first authoring. All Chart.js 4.x controllers are properly registered, and a curated color palette is provided for a consistent look and feel.

Fixes #187

---
*PR created automatically by Jules for task [10706212109241240222](https://jules.google.com/task/10706212109241240222) started by @hasanraiyan*