### PR TITLE
Improve SEO metadata for Coursify course and research public pages

### DIFF
--- a/src/app/coursify/[slug]/layout.js
+++ b/src/app/coursify/[slug]/layout.js
@@ -3,6 +3,7 @@ import CoursifyCourse from '@/models/CoursifyCourse';
 
 export async function generateMetadata({ params }) {
   const { slug } = await params;
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
   try {
     await dbConnect();
     const course = await CoursifyCourse.findOne({ slug, status: 'published', deletedAt: null })
@@ -17,12 +18,21 @@ export async function generateMetadata({ params }) {
     const image = course.thumbnail || '/images/apps/coursify.png';
 
     return {
+      metadataBase: new URL(baseUrl),
       title,
       description,
       keywords: course.tags || [],
+      alternates: {
+        canonical: `/coursify/${slug}`,
+      },
+      robots: {
+        index: true,
+        follow: true,
+      },
       openGraph: {
         title,
         description,
+        url: `/coursify/${slug}`,
         images: [{ url: image, alt: title }],
         type: 'article',
       },

--- a/src/app/coursify/r/[slug]/page.js
+++ b/src/app/coursify/r/[slug]/page.js
@@ -13,13 +13,39 @@ import SummaryCard from '@/components/coursify/SummaryCard';
 
 export async function generateMetadata({ params }) {
   const { slug } = await params;
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
   await dbConnect();
   const research = await CoursifyResearch.findOne({ slug, deletedAt: null }).lean();
   if (!research) return { title: 'Not Found | Coursify' };
 
+  const title = `${research.title} | AI Research | Coursify`;
+  const description = `Read this AI-generated research on ${research.topic}`;
+  const publishedTime = research.createdAt ? new Date(research.createdAt).toISOString() : undefined;
+
   return {
-    title: `${research.title} | AI Research | Coursify`,
-    description: `Read this AI-generated research on ${research.topic}`,
+    metadataBase: new URL(baseUrl),
+    title,
+    description,
+    alternates: {
+      canonical: `/coursify/r/${slug}`,
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+    openGraph: {
+      title,
+      description,
+      url: `/coursify/r/${slug}`,
+      type: 'article',
+      publishedTime,
+      siteName: 'Coursify',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
   };
 }
 


### PR DESCRIPTION
### Motivation

- Ensure both public course pages (`/coursify/{slug}`) and research pages (`/coursify/r/{slug}`) expose complete SEO and social metadata so crawlers and link previews resolve to canonical routes.
- Provide consistent absolute URL generation via `metadataBase` to avoid ambiguous relative links in Open Graph/Twitter previews.

### Description

- Added `metadataBase` (from `NEXT_PUBLIC_BASE_URL` with a sensible fallback) to both course and research metadata generators so Next can produce absolute URLs. (files: `src/app/coursify/[slug]/layout.js`, `src/app/coursify/r/[slug]/page.js`).
- Set `alternates.canonical` to the public route (`/coursify/{slug}` and `/coursify/r/{slug}`) and added `robots: { index: true, follow: true }` to encourage indexing.
- Included `openGraph.url` for both routes and expanded the research page Open Graph fields with `type: 'article'`, `publishedTime`, and `siteName`, plus Twitter card metadata for richer link previews.
- Kept existing DB lookup and page behavior unchanged while enriching the returned metadata objects.

### Testing

- Attempted `pnpm lint` as an automated validation step, which failed due to the repository using ESLint v9 without an `eslint.config.*` file (configuration issue unrelated to these metadata changes).
- There are no other automated tests configured for this repo, so no additional automated test results are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c57e75b8c83209fdd2b545174bd7f)