### PR TITLE
Add Pocketly Telegram reminders

### DIFF
--- a/src/app/actions/contactActions.js
+++ b/src/app/actions/contactActions.js
@@ -7,8 +7,7 @@
 
 import dbConnect from '@/lib/dbConnect';
 import Contact from '@/models/Contact';
-import TelegramSettings from '@/models/TelegramSettings';
-import { decrypt } from '@/lib/crypto';
+import { escapeTelegramMarkdownV2, sendTelegramMessageFromSettings } from '@/lib/telegram';
 import { revalidatePath } from 'next/cache';
 import { headers } from 'next/headers';
 
@@ -73,40 +72,22 @@ function checkRateLimit(ip) {
  */
 async function sendTelegramNotification(contactData) {
   try {
-    const settings = await TelegramSettings.findOne({ isEnabled: true }).lean();
-    if (!settings || !settings.botToken || !settings.chatId) {
-      return;
-    }
-
-    const botToken = decrypt(settings.botToken);
-    if (!botToken) {
-      console.error('Failed to decrypt bot token.');
-      return;
-    }
-
     // Format the message using Telegram's MarkdownV2 syntax
     const message = `
 *New Contact Message* 📩
 
-*Name:* ${contactData.name.replace(/([_*\[\]()~`>#+\-=|{}.!])/g, '\\$1')}
-*Email:* ${contactData.email.replace(/([_*\[\]()~`>#+\-=|{}.!])/g, '\\$1')}
-*Project Type:* \`${contactData.projectType}\`
+*Name:* ${escapeTelegramMarkdownV2(contactData.name)}
+*Email:* ${escapeTelegramMarkdownV2(contactData.email)}
+*Project Type:* ${escapeTelegramMarkdownV2(contactData.projectType)}
 
 *Message:*
-${contactData.message.replace(/([_*\[\]()~`>#+\-=|{}.!])/g, '\\$1')}
+${escapeTelegramMarkdownV2(contactData.message)}
     `.trim();
 
-    const url = `https://api.telegram.org/bot${botToken}/sendMessage`;
-
-    await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        chat_id: settings.chatId,
-        text: message,
-        parse_mode: 'MarkdownV2',
-      }),
-    });
+    const result = await sendTelegramMessageFromSettings(message);
+    if (!result.ok && !result.skipped) {
+      console.error('Failed to send Telegram notification:', result.description);
+    }
   } catch (error) {
     // IMPORTANT: Log the error, but don't throw it.
     // The form submission should still succeed even if the notification fails.

--- a/src/app/api/cron/pocketly-reminder/route.js
+++ b/src/app/api/cron/pocketly-reminder/route.js
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { runPocketlyReminder } from '@/lib/apps/pocketly/reminder';
+
+function authorizeCron(request) {
+  const expected = process.env.CRON_SECRET || process.env.CRON_API_KEY;
+  const authHeader = request.headers.get('authorization');
+
+  if (!expected) {
+    return process.env.NODE_ENV !== 'production';
+  }
+
+  return authHeader === `Bearer ${expected}`;
+}
+
+export async function GET(request) {
+  if (!authorizeCron(request)) {
+    return NextResponse.json({ success: false, message: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const result = await runPocketlyReminder({ request });
+    return NextResponse.json(result, { status: result.status || 200 });
+  } catch (error) {
+    console.error('[PocketlyReminderCron] Failed to run reminder:', error);
+    return NextResponse.json(
+      { success: false, message: error.message || 'Failed to run Pocketly reminder' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/money/reminder-settings/route.js
+++ b/src/app/api/money/reminder-settings/route.js
@@ -1,0 +1,110 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/dbConnect';
+import { requireAdminAuth } from '@/lib/money-auth';
+import PocketlyReminderSettings from '@/models/PocketlyReminderSettings';
+
+const REMINDER_MODES = new Set(['if_no_transactions', 'always']);
+
+function serializeSettings(settings) {
+  return {
+    id: settings._id.toString(),
+    isEnabled: Boolean(settings.isEnabled),
+    reminderTime: settings.reminderTime || '21:00',
+    timezone: settings.timezone || 'Asia/Kolkata',
+    reminderMode: settings.reminderMode || 'if_no_transactions',
+    lastReminderSentAt: settings.lastReminderSentAt
+      ? new Date(settings.lastReminderSentAt).toISOString()
+      : null,
+    lastReminderSentDate: settings.lastReminderSentDate || null,
+    updatedAt: settings.updatedAt ? new Date(settings.updatedAt).toISOString() : null,
+  };
+}
+
+function isValidTimezone(timezone) {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone }).format(new Date());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function validatePayload(payload) {
+  const errors = [];
+  const next = {};
+
+  if (typeof payload.isEnabled === 'boolean') {
+    next.isEnabled = payload.isEnabled;
+  }
+
+  if (typeof payload.reminderTime === 'string') {
+    if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(payload.reminderTime)) {
+      errors.push('Reminder time must use HH:mm format.');
+    } else {
+      next.reminderTime = payload.reminderTime;
+    }
+  }
+
+  if (typeof payload.timezone === 'string') {
+    const timezone = payload.timezone.trim();
+    if (!timezone || !isValidTimezone(timezone)) {
+      errors.push('Timezone is invalid.');
+    } else {
+      next.timezone = timezone;
+    }
+  }
+
+  if (typeof payload.reminderMode === 'string') {
+    if (!REMINDER_MODES.has(payload.reminderMode)) {
+      errors.push('Reminder mode is invalid.');
+    } else {
+      next.reminderMode = payload.reminderMode;
+    }
+  }
+
+  return { errors, next };
+}
+
+export async function GET(request) {
+  const session = await requireAdminAuth(request);
+  if (session instanceof NextResponse) return session;
+
+  try {
+    await dbConnect();
+    const settings = await PocketlyReminderSettings.getSettings();
+    return NextResponse.json({ success: true, settings: serializeSettings(settings) });
+  } catch (error) {
+    console.error('[PocketlyReminderSettings] Failed to load settings:', error);
+    return NextResponse.json(
+      { success: false, message: 'Failed to load reminder settings' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request) {
+  const session = await requireAdminAuth(request);
+  if (session instanceof NextResponse) return session;
+
+  try {
+    await dbConnect();
+    const payload = await request.json();
+    const { errors, next } = validatePayload(payload || {});
+
+    if (errors.length > 0) {
+      return NextResponse.json({ success: false, message: errors[0], errors }, { status: 400 });
+    }
+
+    const settings = await PocketlyReminderSettings.getSettings();
+    Object.assign(settings, next);
+    await settings.save();
+
+    return NextResponse.json({ success: true, settings: serializeSettings(settings) });
+  } catch (error) {
+    console.error('[PocketlyReminderSettings] Failed to save settings:', error);
+    return NextResponse.json(
+      { success: false, message: 'Failed to save reminder settings' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/pocketly-tracker/FinanceSettingsTab.js
+++ b/src/components/pocketly-tracker/FinanceSettingsTab.js
@@ -14,6 +14,8 @@ import {
   ExternalLink,
   Smartphone,
   QrCode,
+  Bell,
+  Save,
 } from 'lucide-react';
 import QRCode from 'react-qr-code';
 import { useMoney } from '@/context/MoneyContext';
@@ -26,6 +28,17 @@ export default function FinanceSettingsTab() {
 
   const [baseUrl, setBaseUrl] = useState('');
   const [mcpUrl, setMcpUrl] = useState('');
+  const [reminderSettings, setReminderSettings] = useState({
+    isEnabled: false,
+    reminderTime: '21:00',
+    timezone: 'Asia/Kolkata',
+    reminderMode: 'if_no_transactions',
+    lastReminderSentAt: null,
+    lastReminderSentDate: null,
+  });
+  const [isReminderLoading, setIsReminderLoading] = useState(true);
+  const [isReminderSaving, setIsReminderSaving] = useState(false);
+  const [reminderStatus, setReminderStatus] = useState(null);
 
   // Mobile QR state
   const [mobileQr, setMobileQr] = useState(null);
@@ -49,6 +62,27 @@ export default function FinanceSettingsTab() {
       setBaseUrl(origin);
       setMcpUrl(`${origin}/api/mcp/pocketly`);
     }
+  }, []);
+
+  useEffect(() => {
+    async function loadReminderSettings() {
+      setIsReminderLoading(true);
+      try {
+        const res = await fetch('/api/money/reminder-settings');
+        const data = await res.json();
+        if (!res.ok || data.success === false) {
+          throw new Error(data.message || 'Failed to load reminder settings');
+        }
+        setReminderSettings((prev) => ({ ...prev, ...(data.settings || {}) }));
+      } catch (error) {
+        console.error('Failed to load reminder settings:', error);
+        setReminderStatus({ type: 'error', message: error.message || 'Failed to load reminder' });
+      } finally {
+        setIsReminderLoading(false);
+      }
+    }
+
+    loadReminderSettings();
   }, []);
 
   // Load connected apps
@@ -111,6 +145,39 @@ export default function FinanceSettingsTab() {
     }
   };
 
+  const handleReminderChange = (key, value) => {
+    setReminderStatus(null);
+    setReminderSettings((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSaveReminderSettings = async () => {
+    setIsReminderSaving(true);
+    setReminderStatus(null);
+    try {
+      const res = await fetch('/api/money/reminder-settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          isEnabled: reminderSettings.isEnabled,
+          reminderTime: reminderSettings.reminderTime,
+          timezone: reminderSettings.timezone,
+          reminderMode: reminderSettings.reminderMode,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok || data.success === false) {
+        throw new Error(data.message || 'Failed to save reminder settings');
+      }
+      setReminderSettings((prev) => ({ ...prev, ...(data.settings || {}) }));
+      setReminderStatus({ type: 'success', message: 'Reminder settings saved' });
+    } catch (error) {
+      console.error('Failed to save reminder settings:', error);
+      setReminderStatus({ type: 'error', message: error.message || 'Failed to save reminder' });
+    } finally {
+      setIsReminderSaving(false);
+    }
+  };
+
   const handleClearAll = async () => {
     const confirmed = window.confirm('Clear all finance data? This cannot be undone.');
     if (!confirmed) return;
@@ -124,36 +191,38 @@ export default function FinanceSettingsTab() {
   };
 
   return (
-    <div className="mb-6 pb-4 pt-6">
-      <div className="w-full px-4 lg:px-6">
-        <div className="w-full max-w-6xl mx-auto space-y-6">
+    <div className="mb-6 pb-4 pt-3 sm:pt-6">
+      <div className="w-full px-3 sm:px-4 lg:px-6">
+        <div className="w-full max-w-6xl mx-auto space-y-4 sm:space-y-6">
           {/* Data Overview */}
-          <div className="bg-white border border-[#e5e3d8] rounded-xl p-6">
-            <div className="flex items-center gap-3 mb-5">
-              <div className="w-10 h-10 rounded-xl bg-[#1f644e]/10 flex items-center justify-center">
+          <div className="bg-white border border-[#e5e3d8] rounded-xl p-4 sm:p-6">
+            <div className="flex items-center gap-3 mb-4 sm:mb-5">
+              <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-xl bg-[#1f644e]/10 flex items-center justify-center shrink-0">
                 <Database className="w-5 h-5 text-[#1f644e]" />
               </div>
-              <div>
+              <div className="min-w-0">
                 <h3 className="text-sm font-bold text-[#1e3a34]">Data Overview</h3>
                 <p className="text-xs text-[#7c8e88]">Your current finance data</p>
               </div>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-              <div className="bg-[#f0f5f2] rounded-xl p-4 text-center">
-                <p className="text-2xl font-bold text-[#1f644e]">{accounts.length}</p>
+            <div className="grid grid-cols-3 gap-2 sm:gap-4">
+              <div className="bg-[#f0f5f2] rounded-xl p-3 sm:p-4 text-center min-w-0">
+                <p className="text-xl sm:text-2xl font-bold text-[#1f644e]">{accounts.length}</p>
                 <p className="text-xs text-[#7c8e88] mt-1 font-bold uppercase tracking-wider">
                   Accounts
                 </p>
               </div>
-              <div className="bg-[#f0f5f2] rounded-xl p-4 text-center">
-                <p className="text-2xl font-bold text-[#1f644e]">{stats.totalTransactionCount}</p>
+              <div className="bg-[#f0f5f2] rounded-xl p-3 sm:p-4 text-center min-w-0">
+                <p className="text-xl sm:text-2xl font-bold text-[#1f644e]">
+                  {stats.totalTransactionCount}
+                </p>
                 <p className="text-xs text-[#7c8e88] mt-1 font-bold uppercase tracking-wider">
                   Transactions
                 </p>
               </div>
-              <div className="bg-[#f0f5f2] rounded-xl p-4 text-center">
-                <p className="text-2xl font-bold text-[#1f644e]">{categories.length}</p>
+              <div className="bg-[#f0f5f2] rounded-xl p-3 sm:p-4 text-center min-w-0">
+                <p className="text-xl sm:text-2xl font-bold text-[#1f644e]">{categories.length}</p>
                 <p className="text-xs text-[#7c8e88] mt-1 font-bold uppercase tracking-wider">
                   Categories
                 </p>
@@ -162,21 +231,21 @@ export default function FinanceSettingsTab() {
           </div>
 
           {/* Sync & Refresh */}
-          <div className="bg-white border border-[#e5e3d8] rounded-xl p-6">
-            <div className="flex items-center gap-3 mb-5">
-              <div className="w-10 h-10 rounded-xl bg-[#4a86e8]/10 flex items-center justify-center">
+          <div className="bg-white border border-[#e5e3d8] rounded-xl p-4 sm:p-6">
+            <div className="flex items-center gap-3 mb-4 sm:mb-5">
+              <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-xl bg-[#4a86e8]/10 flex items-center justify-center shrink-0">
                 <RefreshCw className="w-5 h-5 text-[#4a86e8]" />
               </div>
-              <div>
+              <div className="min-w-0">
                 <h3 className="text-sm font-bold text-[#1e3a34]">Sync & Refresh</h3>
                 <p className="text-xs text-[#7c8e88]">Pull the latest data from the server</p>
               </div>
             </div>
 
-            <div className="flex items-center justify-between bg-[#f7faf7] border border-[#d6dfd9] rounded-xl p-4">
-              <div className="flex items-center gap-3">
-                <Shield className="w-5 h-5 text-[#1f644e]" />
-                <div>
+            <div className="flex flex-col gap-4 bg-[#f7faf7] border border-[#d6dfd9] rounded-xl p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-start gap-3 min-w-0">
+                <Shield className="w-5 h-5 text-[#1f644e] mt-0.5 shrink-0" />
+                <div className="min-w-0">
                   <p className="text-sm font-bold text-[#1e3a34]">Refresh Data</p>
                   <p className="text-xs text-[#7c8e88]">Sync with the latest server records</p>
                 </div>
@@ -184,7 +253,7 @@ export default function FinanceSettingsTab() {
               <button
                 onClick={fetchData}
                 disabled={isSyncing}
-                className="flex items-center gap-2 rounded-lg bg-[#1f644e] px-4 py-2 text-sm font-bold text-white transition hover:bg-[#17503e] disabled:opacity-60 cursor-pointer shrink-0"
+                className="flex w-full items-center justify-center gap-2 rounded-lg bg-[#1f644e] px-4 py-2.5 text-sm font-bold text-white transition hover:bg-[#17503e] disabled:opacity-60 cursor-pointer sm:w-auto sm:shrink-0 sm:py-2"
               >
                 <RefreshCw className={`h-4 w-4 ${isSyncing ? 'animate-spin' : ''}`} />
                 {isSyncing ? 'Syncing...' : 'Refresh'}
@@ -192,20 +261,138 @@ export default function FinanceSettingsTab() {
             </div>
           </div>
 
+          {/* Daily Reminder */}
+          <div className="bg-white border border-[#e5e3d8] rounded-xl p-4 sm:p-6">
+            <div className="flex items-center gap-3 mb-4 sm:mb-5">
+              <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-xl bg-[#1f644e]/10 flex items-center justify-center shrink-0">
+                <Bell className="w-5 h-5 text-[#1f644e]" />
+              </div>
+              <div className="min-w-0">
+                <h3 className="text-sm font-bold text-[#1e3a34]">Daily Reminder</h3>
+                <p className="text-xs text-[#7c8e88]">
+                  Telegram nudges when you forget to log transactions
+                </p>
+              </div>
+            </div>
+
+            {isReminderLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="w-5 h-5 animate-spin text-[#7c8e88]" />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="flex items-start justify-between gap-4 bg-[#f7faf7] border border-[#d6dfd9] rounded-xl p-4">
+                  <div className="min-w-0">
+                    <p className="text-sm font-bold text-[#1e3a34]">Telegram reminder</p>
+                    <p className="text-xs text-[#7c8e88] mt-0.5">
+                      Uses the Telegram bot configured in admin settings
+                    </p>
+                  </div>
+                  <label className="relative inline-flex cursor-pointer items-center">
+                    <input
+                      type="checkbox"
+                      checked={reminderSettings.isEnabled}
+                      onChange={(event) => handleReminderChange('isEnabled', event.target.checked)}
+                      className="peer sr-only"
+                    />
+                    <span className="h-6 w-11 rounded-full bg-[#d6dfd9] transition peer-checked:bg-[#1f644e]" />
+                    <span className="absolute left-1 top-1 h-4 w-4 rounded-full bg-white transition peer-checked:translate-x-5" />
+                  </label>
+                </div>
+
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 sm:gap-4">
+                  <div>
+                    <label className="block text-xs font-bold uppercase tracking-wider text-[#7c8e88] mb-2">
+                      Reminder time
+                    </label>
+                    <input
+                      type="time"
+                      value={reminderSettings.reminderTime}
+                      onChange={(event) => handleReminderChange('reminderTime', event.target.value)}
+                      className="w-full rounded-xl border border-[#e5e3d8] bg-[#fcfbf5] px-3 py-3 text-sm font-bold text-[#1e3a34] outline-none focus:border-[#1f644e] sm:py-2.5"
+                    />
+                  </div>
+
+                  <div>
+                    <label className="block text-xs font-bold uppercase tracking-wider text-[#7c8e88] mb-2">
+                      Mode
+                    </label>
+                    <select
+                      value={reminderSettings.reminderMode}
+                      onChange={(event) => handleReminderChange('reminderMode', event.target.value)}
+                      className="w-full rounded-xl border border-[#e5e3d8] bg-[#fcfbf5] px-3 py-3 text-sm font-bold text-[#1e3a34] outline-none focus:border-[#1f644e] sm:py-2.5"
+                    >
+                      <option value="if_no_transactions">Only if no transactions today</option>
+                      <option value="always">Always remind me daily</option>
+                    </select>
+                  </div>
+
+                  <div>
+                    <label className="block text-xs font-bold uppercase tracking-wider text-[#7c8e88] mb-2">
+                      Timezone
+                    </label>
+                    <input
+                      type="text"
+                      value={reminderSettings.timezone}
+                      onChange={(event) => handleReminderChange('timezone', event.target.value)}
+                      className="w-full rounded-xl border border-[#e5e3d8] bg-[#fcfbf5] px-3 py-3 text-sm font-bold text-[#1e3a34] outline-none focus:border-[#1f644e] sm:py-2.5"
+                    />
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="text-xs text-[#7c8e88] min-w-0">
+                    {reminderSettings.lastReminderSentAt ? (
+                      <>
+                        Last sent {new Date(reminderSettings.lastReminderSentAt).toLocaleString()}
+                      </>
+                    ) : (
+                      'No reminder has been sent yet'
+                    )}
+                  </div>
+                  <button
+                    onClick={handleSaveReminderSettings}
+                    disabled={isReminderSaving}
+                    className="flex w-full items-center justify-center gap-2 rounded-lg bg-[#1f644e] px-4 py-2.5 text-sm font-bold text-white transition hover:bg-[#17503e] disabled:opacity-60 cursor-pointer sm:w-auto sm:py-2"
+                  >
+                    {isReminderSaving ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Save className="h-4 w-4" />
+                    )}
+                    {isReminderSaving ? 'Saving...' : 'Save Reminder'}
+                  </button>
+                </div>
+
+                {reminderStatus && (
+                  <div
+                    className={`rounded-xl border px-4 py-3 text-sm font-semibold ${
+                      reminderStatus.type === 'success'
+                        ? 'border-[#d9e6df] bg-[#f0f5f2] text-[#1f644e]'
+                        : 'border-[#f0d2d2] bg-[#fef2f2] text-[#c94c4c]'
+                    }`}
+                  >
+                    {reminderStatus.message}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
           {/* Export Data */}
-          <div className="bg-white border border-[#e5e3d8] rounded-xl p-6">
-            <div className="flex items-center gap-3 mb-5">
-              <div className="w-10 h-10 rounded-xl bg-[#8b5cf6]/10 flex items-center justify-center">
+          <div className="bg-white border border-[#e5e3d8] rounded-xl p-4 sm:p-6">
+            <div className="flex items-center gap-3 mb-4 sm:mb-5">
+              <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-xl bg-[#8b5cf6]/10 flex items-center justify-center shrink-0">
                 <Download className="w-5 h-5 text-[#8b5cf6]" />
               </div>
-              <div>
+              <div className="min-w-0">
                 <h3 className="text-sm font-bold text-[#1e3a34]">Export Data</h3>
                 <p className="text-xs text-[#7c8e88]">Download your transaction history</p>
               </div>
             </div>
 
-            <div className="flex items-center justify-between bg-[#f7faf7] border border-[#d6dfd9] rounded-xl p-4">
-              <div>
+            <div className="flex flex-col gap-4 bg-[#f7faf7] border border-[#d6dfd9] rounded-xl p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0">
                 <p className="text-sm font-bold text-[#1e3a34]">Export as PDF</p>
                 <p className="text-xs text-[#7c8e88] mt-0.5">
                   Generate a report of your transactions
@@ -213,7 +400,7 @@ export default function FinanceSettingsTab() {
               </div>
               <button
                 onClick={() => setIsExportModalOpen(true)}
-                className="flex items-center gap-2 rounded-lg bg-[#1f644e] px-4 py-2 text-sm font-bold text-white transition hover:bg-[#17503e] cursor-pointer shrink-0"
+                className="flex w-full items-center justify-center gap-2 rounded-lg bg-[#1f644e] px-4 py-2.5 text-sm font-bold text-white transition hover:bg-[#17503e] cursor-pointer sm:w-auto sm:shrink-0 sm:py-2"
               >
                 <Download className="h-4 w-4" />
                 Export
@@ -222,12 +409,12 @@ export default function FinanceSettingsTab() {
           </div>
 
           {/* MCP Server */}
-          <div className="bg-white border border-[#e5e3d8] rounded-xl p-6">
-            <div className="flex items-center gap-3 mb-5">
-              <div className="w-10 h-10 rounded-xl bg-[#8b5cf6]/10 flex items-center justify-center">
+          <div className="bg-white border border-[#e5e3d8] rounded-xl p-4 sm:p-6">
+            <div className="flex items-center gap-3 mb-4 sm:mb-5">
+              <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-xl bg-[#8b5cf6]/10 flex items-center justify-center shrink-0">
                 <Plug className="w-5 h-5 text-[#8b5cf6]" />
               </div>
-              <div>
+              <div className="min-w-0">
                 <h3 className="text-sm font-bold text-[#1e3a34]">MCP Server</h3>
                 <p className="text-xs text-[#7c8e88]">
                   Connect Pocketly to ChatGPT and other AI assistants via MCP
@@ -238,11 +425,11 @@ export default function FinanceSettingsTab() {
             <div className="space-y-4">
               <div className="space-y-2">
                 <label className="block text-sm font-medium text-gray-700">MCP Endpoint</label>
-                <div className="flex gap-2">
+                <div className="flex flex-col gap-2 sm:flex-row">
                   <input
                     readOnly
                     value={mcpUrl}
-                    className="w-full p-2.5 border rounded-lg bg-neutral-50 text-sm font-mono"
+                    className="w-full min-w-0 p-3 border rounded-lg bg-neutral-50 text-xs font-mono sm:p-2.5 sm:text-sm"
                   />
                   <button
                     type="button"
@@ -250,7 +437,7 @@ export default function FinanceSettingsTab() {
                       navigator.clipboard?.writeText(mcpUrl);
                       alert('MCP endpoint copied');
                     }}
-                    className="px-4 py-2 bg-[#1f644e] text-white rounded-lg text-sm font-bold hover:bg-[#17503e] transition cursor-pointer shrink-0"
+                    className="w-full px-4 py-2.5 bg-[#1f644e] text-white rounded-lg text-sm font-bold hover:bg-[#17503e] transition cursor-pointer sm:w-auto sm:shrink-0 sm:py-2"
                   >
                     Copy
                   </button>
@@ -269,19 +456,19 @@ export default function FinanceSettingsTab() {
                     href={`${baseUrl}/.well-known/oauth-authorization-server`}
                     target="_blank"
                     rel="noreferrer"
-                    className="flex items-center gap-2 p-2.5 rounded-lg border border-[#e5e3d8] bg-neutral-50 hover:bg-neutral-100 transition text-xs font-mono text-[#1f644e]"
+                    className="flex min-w-0 items-center gap-2 p-3 rounded-lg border border-[#e5e3d8] bg-neutral-50 hover:bg-neutral-100 transition text-xs font-mono text-[#1f644e] sm:p-2.5"
                   >
                     <ExternalLink className="w-3.5 h-3.5 shrink-0" />
-                    OAuth Authorization Server
+                    <span className="min-w-0 break-words">OAuth Authorization Server</span>
                   </a>
                   <a
                     href={`${baseUrl}/.well-known/openapi.json`}
                     target="_blank"
                     rel="noreferrer"
-                    className="flex items-center gap-2 p-2.5 rounded-lg border border-[#e5e3d8] bg-neutral-50 hover:bg-neutral-100 transition text-xs font-mono text-[#1f644e]"
+                    className="flex min-w-0 items-center gap-2 p-3 rounded-lg border border-[#e5e3d8] bg-neutral-50 hover:bg-neutral-100 transition text-xs font-mono text-[#1f644e] sm:p-2.5"
                   >
                     <ExternalLink className="w-3.5 h-3.5 shrink-0" />
-                    OpenAPI Spec
+                    <span className="min-w-0 break-words">OpenAPI Spec</span>
                   </a>
                 </div>
               </div>
@@ -289,12 +476,12 @@ export default function FinanceSettingsTab() {
           </div>
 
           {/* Connected Apps */}
-          <div className="bg-white border border-[#e5e3d8] rounded-xl p-6">
-            <div className="flex items-center gap-3 mb-5">
-              <div className="w-10 h-10 rounded-xl bg-[#4a86e8]/10 flex items-center justify-center">
+          <div className="bg-white border border-[#e5e3d8] rounded-xl p-4 sm:p-6">
+            <div className="flex items-center gap-3 mb-4 sm:mb-5">
+              <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-xl bg-[#4a86e8]/10 flex items-center justify-center shrink-0">
                 <Shield className="w-5 h-5 text-[#4a86e8]" />
               </div>
-              <div>
+              <div className="min-w-0">
                 <h3 className="text-sm font-bold text-[#1e3a34]">Connected Apps</h3>
                 <p className="text-xs text-[#7c8e88]">
                   AI assistants and third-party apps with access to your data
@@ -319,11 +506,11 @@ export default function FinanceSettingsTab() {
                 {connectedApps.map((app) => (
                   <div
                     key={app.id}
-                    className="flex items-center justify-between bg-[#f7faf7] border border-[#d6dfd9] rounded-xl p-4"
+                    className="flex flex-col gap-3 bg-[#f7faf7] border border-[#d6dfd9] rounded-xl p-4 sm:flex-row sm:items-center sm:justify-between"
                   >
                     <div className="min-w-0">
                       <p className="text-sm font-bold text-[#1e3a34] truncate">{app.clientName}</p>
-                      <div className="flex items-center gap-2 mt-1">
+                      <div className="flex flex-wrap items-center gap-2 mt-1">
                         <span className="text-[10px] uppercase font-bold tracking-wider px-1.5 py-0.5 rounded bg-[#1f644e]/10 text-[#1f644e]">
                           {getConnectionLabel(app)}
                         </span>
@@ -342,7 +529,7 @@ export default function FinanceSettingsTab() {
                     <button
                       onClick={() => handleRevoke(app.id)}
                       disabled={revokingId === app.id}
-                      className="flex items-center gap-1.5 rounded-lg border border-red-200 px-3 py-1.5 text-xs font-bold text-red-600 hover:bg-red-50 transition cursor-pointer shrink-0 disabled:opacity-60"
+                      className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-red-200 px-3 py-2 text-xs font-bold text-red-600 hover:bg-red-50 transition cursor-pointer disabled:opacity-60 sm:w-auto sm:shrink-0 sm:py-1.5"
                     >
                       {revokingId === app.id ? (
                         <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -358,12 +545,12 @@ export default function FinanceSettingsTab() {
           </div>
 
           {/* About */}
-          <div className="bg-white border border-[#e5e3d8] rounded-xl p-6">
-            <div className="flex items-center gap-3 mb-5">
-              <div className="w-10 h-10 rounded-xl bg-[#f59e0b]/10 flex items-center justify-center">
+          <div className="bg-white border border-[#e5e3d8] rounded-xl p-4 sm:p-6">
+            <div className="flex items-center gap-3 mb-4 sm:mb-5">
+              <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-xl bg-[#f59e0b]/10 flex items-center justify-center shrink-0">
                 <Info className="w-5 h-5 text-[#f59e0b]" />
               </div>
-              <div>
+              <div className="min-w-0">
                 <h3 className="text-sm font-bold text-[#1e3a34]">About</h3>
                 <p className="text-xs text-[#7c8e88]">App information</p>
               </div>
@@ -386,12 +573,12 @@ export default function FinanceSettingsTab() {
           </div>
 
           {/* Mobile App */}
-          <div className="bg-white border border-[#e5e3d8] rounded-xl p-6">
-            <div className="flex items-center gap-3 mb-5">
-              <div className="w-10 h-10 rounded-xl bg-[#1f644e]/10 flex items-center justify-center">
+          <div className="bg-white border border-[#e5e3d8] rounded-xl p-4 sm:p-6">
+            <div className="flex items-center gap-3 mb-4 sm:mb-5">
+              <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-xl bg-[#1f644e]/10 flex items-center justify-center shrink-0">
                 <Smartphone className="w-5 h-5 text-[#1f644e]" />
               </div>
-              <div>
+              <div className="min-w-0">
                 <h3 className="text-sm font-bold text-[#1e3a34]">Mobile App</h3>
                 <p className="text-xs text-[#7c8e88]">
                   Connect the Pocketly Android app to this server
@@ -400,8 +587,8 @@ export default function FinanceSettingsTab() {
             </div>
 
             <div className="space-y-4">
-              <div className="flex items-center justify-between bg-[#f7faf7] border border-[#d6dfd9] rounded-xl p-4">
-                <div>
+              <div className="flex flex-col gap-4 bg-[#f7faf7] border border-[#d6dfd9] rounded-xl p-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-w-0">
                   <p className="text-sm font-bold text-[#1e3a34]">Generate QR Code</p>
                   <p className="text-xs text-[#7c8e88] mt-0.5">
                     Scan with the Pocketly app to create a revocable Android session
@@ -410,7 +597,7 @@ export default function FinanceSettingsTab() {
                 <button
                   onClick={handleGenerateMobileQr}
                   disabled={mobileQrLoading}
-                  className="flex items-center gap-2 rounded-lg bg-[#1f644e] px-4 py-2 text-sm font-bold text-white transition hover:bg-[#17503e] disabled:opacity-60 cursor-pointer shrink-0"
+                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-[#1f644e] px-4 py-2.5 text-sm font-bold text-white transition hover:bg-[#17503e] disabled:opacity-60 cursor-pointer sm:w-auto sm:shrink-0 sm:py-2"
                 >
                   {mobileQrLoading ? (
                     <Loader2 className="h-4 w-4 animate-spin" />
@@ -423,8 +610,8 @@ export default function FinanceSettingsTab() {
 
               {mobileQr && (
                 <div className="flex flex-col items-center gap-3 p-6 bg-white border-2 border-[#e5e3d8] rounded-xl">
-                  <div className="p-4 bg-white rounded-xl border border-[#e5e3d8]">
-                    <QRCode value={mobileQr} size={200} />
+                  <div className="p-3 sm:p-4 bg-white rounded-xl border border-[#e5e3d8]">
+                    <QRCode value={mobileQr} size={180} />
                   </div>
                   <p className="text-xs text-[#7c8e88] text-center">
                     Open the Pocketly Android app and tap <strong>Scan QR</strong> to connect.
@@ -443,19 +630,19 @@ export default function FinanceSettingsTab() {
           </div>
 
           {/* Danger Zone */}
-          <div className="bg-[#fef2f2] border border-[#f0d2d2] rounded-xl p-6">
-            <div className="flex items-center gap-3 mb-5">
-              <div className="w-10 h-10 rounded-xl bg-[#c94c4c]/10 flex items-center justify-center">
+          <div className="bg-[#fef2f2] border border-[#f0d2d2] rounded-xl p-4 sm:p-6">
+            <div className="flex items-center gap-3 mb-4 sm:mb-5">
+              <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-xl bg-[#c94c4c]/10 flex items-center justify-center shrink-0">
                 <Trash2 className="w-5 h-5 text-[#c94c4c]" />
               </div>
-              <div>
+              <div className="min-w-0">
                 <h3 className="text-sm font-bold text-[#c94c4c]">Danger Zone</h3>
                 <p className="text-xs text-[#c94c4c]/70">Irreversible actions</p>
               </div>
             </div>
 
-            <div className="flex items-center justify-between bg-white border border-[#f0d2d2] rounded-xl p-4">
-              <div>
+            <div className="flex flex-col gap-4 bg-white border border-[#f0d2d2] rounded-xl p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0">
                 <p className="text-sm font-bold text-[#1e3a34]">Clear All Data</p>
                 <p className="text-xs text-[#7c8e88] mt-0.5">
                   Permanently delete all accounts, transactions, categories, and budgets
@@ -464,7 +651,7 @@ export default function FinanceSettingsTab() {
               <button
                 onClick={handleClearAll}
                 disabled={isClearing}
-                className="flex items-center gap-2 rounded-lg bg-[#c94c4c] px-4 py-2 text-sm font-bold text-white transition hover:bg-[#b24040] disabled:opacity-60 cursor-pointer shrink-0"
+                className="flex w-full items-center justify-center gap-2 rounded-lg bg-[#c94c4c] px-4 py-2.5 text-sm font-bold text-white transition hover:bg-[#b24040] disabled:opacity-60 cursor-pointer sm:w-auto sm:shrink-0 sm:py-2"
               >
                 <Trash2 className="h-4 w-4" />
                 {isClearing ? 'Clearing...' : 'Clear All'}

--- a/src/lib/apps/pocketly/reminder.js
+++ b/src/lib/apps/pocketly/reminder.js
@@ -1,0 +1,211 @@
+import dbConnect from '@/lib/dbConnect';
+import Transaction from '@/models/Transaction';
+import PocketlyReminderSettings from '@/models/PocketlyReminderSettings';
+import { escapeTelegramMarkdownV2, sendTelegramMessageFromSettings } from '@/lib/telegram';
+
+function getBaseUrl(request) {
+  if (process.env.NEXT_PUBLIC_BASE_URL) return process.env.NEXT_PUBLIC_BASE_URL.replace(/\/$/, '');
+  if (process.env.NEXTAUTH_URL) return process.env.NEXTAUTH_URL.replace(/\/$/, '');
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  return new URL(request.url).origin;
+}
+
+function getLocalParts(date, timezone) {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    hourCycle: 'h23',
+  }).formatToParts(date);
+
+  const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return {
+    year: Number(values.year),
+    month: Number(values.month),
+    day: Number(values.day),
+    hour: Number(values.hour),
+    minute: Number(values.minute),
+    second: Number(values.second),
+    dateKey: `${values.year}-${values.month}-${values.day}`,
+  };
+}
+
+function getTimezoneOffsetMs(date, timezone) {
+  const parts = getLocalParts(date, timezone);
+  const localAsUtc = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second
+  );
+  return localAsUtc - date.getTime();
+}
+
+function zonedTimeToUtc(parts, timezone) {
+  const localAsUtc = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour || 0,
+    parts.minute || 0,
+    parts.second || 0,
+    parts.millisecond || 0
+  );
+
+  let utcDate = new Date(localAsUtc - getTimezoneOffsetMs(new Date(localAsUtc), timezone));
+  utcDate = new Date(localAsUtc - getTimezoneOffsetMs(utcDate, timezone));
+  return utcDate;
+}
+
+function getLocalDayRangeUtc(date, timezone) {
+  const local = getLocalParts(date, timezone);
+  const start = zonedTimeToUtc(
+    {
+      year: local.year,
+      month: local.month,
+      day: local.day,
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+    },
+    timezone
+  );
+  const nextLocalDay = new Date(Date.UTC(local.year, local.month - 1, local.day + 1));
+  const nextLocal = {
+    year: nextLocalDay.getUTCFullYear(),
+    month: nextLocalDay.getUTCMonth() + 1,
+    day: nextLocalDay.getUTCDate(),
+    hour: 0,
+    minute: 0,
+    second: 0,
+    millisecond: 0,
+  };
+  const end = zonedTimeToUtc(nextLocal, timezone);
+  return { start, end, dateKey: local.dateKey, local };
+}
+
+function hasReminderTimeArrived(local, reminderTime) {
+  const [hour, minute] = reminderTime.split(':').map(Number);
+  return local.hour * 60 + local.minute >= hour * 60 + minute;
+}
+
+function createReminderMessage({ transactionCount, reminderMode, baseUrl, isTest }) {
+  const modeLine =
+    reminderMode === 'always'
+      ? 'Daily check\\-in for your Pocketly records'
+      : 'No transactions logged today';
+
+  const transactionLine =
+    reminderMode === 'always'
+      ? `Transactions today: ${escapeTelegramMarkdownV2(transactionCount)}`
+      : 'Add them before you forget';
+
+  const testLine = isTest ? '\n_Test run from Pocketly settings_\n' : '';
+
+  return `
+*Pocketly Reminder*
+${testLine}
+${modeLine}
+${transactionLine}
+
+Quick check:
+\\- Food, tea, or groceries?
+\\- UPI or card payment?
+\\- Travel or shopping?
+\\- Income or transfer?
+
+Open Pocketly:
+${escapeTelegramMarkdownV2(`${baseUrl}/apps/pocketly`)}
+  `.trim();
+}
+
+export async function runPocketlyReminder({ request, force = false, persistLastSent = true } = {}) {
+  await dbConnect();
+
+  const settings = await PocketlyReminderSettings.getSettings();
+  if (!settings.isEnabled && !force) {
+    return { success: true, skipped: true, reason: 'Reminder disabled' };
+  }
+
+  const now = new Date();
+  const timezone = settings.timezone || 'Asia/Kolkata';
+  const reminderTime = settings.reminderTime || '21:00';
+  const reminderMode = settings.reminderMode || 'if_no_transactions';
+  const { start, end, dateKey, local } = getLocalDayRangeUtc(now, timezone);
+
+  if (!force && !hasReminderTimeArrived(local, reminderTime)) {
+    return {
+      success: true,
+      skipped: true,
+      reason: 'Reminder time has not arrived',
+      localDate: dateKey,
+      reminderTime,
+      timezone,
+    };
+  }
+
+  if (!force && settings.lastReminderSentDate === dateKey) {
+    return {
+      success: true,
+      skipped: true,
+      reason: 'Reminder already sent today',
+      localDate: dateKey,
+    };
+  }
+
+  const transactionCount = await Transaction.countDocuments({
+    deletedAt: null,
+    date: { $gte: start, $lt: end },
+  });
+
+  if (!force && reminderMode === 'if_no_transactions' && transactionCount > 0) {
+    return {
+      success: true,
+      skipped: true,
+      reason: 'Transactions already logged today',
+      transactionCount,
+      localDate: dateKey,
+    };
+  }
+
+  const result = await sendTelegramMessageFromSettings(
+    createReminderMessage({
+      transactionCount,
+      reminderMode,
+      baseUrl: getBaseUrl(request),
+      isTest: force,
+    })
+  );
+
+  if (!result.ok) {
+    return {
+      success: false,
+      message: result.description || 'Failed to send Telegram reminder',
+      skipped: result.skipped || false,
+      status: result.skipped ? 200 : 500,
+    };
+  }
+
+  if (persistLastSent) {
+    settings.lastReminderSentAt = now;
+    settings.lastReminderSentDate = dateKey;
+    await settings.save();
+  }
+
+  return {
+    success: true,
+    sent: true,
+    localDate: dateKey,
+    reminderMode,
+    transactionCount,
+    test: force,
+  };
+}

--- a/src/lib/telegram.js
+++ b/src/lib/telegram.js
@@ -1,0 +1,69 @@
+import TelegramSettings from '@/models/TelegramSettings';
+import { decrypt } from '@/lib/crypto';
+
+const MARKDOWN_V2_SPECIAL_CHARS = /([_*\[\]()~`>#+\-=|{}.!])/g;
+
+export function escapeTelegramMarkdownV2(value) {
+  return String(value || '').replace(MARKDOWN_V2_SPECIAL_CHARS, '\\$1');
+}
+
+export async function sendTelegramMessage({ botToken, chatId, text, parseMode = 'MarkdownV2' }) {
+  if (!botToken || !chatId || !text) {
+    return {
+      ok: false,
+      description: 'Missing bot token, chat ID, or message text.',
+    };
+  }
+
+  try {
+    const response = await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text,
+        parse_mode: parseMode,
+      }),
+    });
+
+    const payload = await response.json().catch(() => ({}));
+
+    if (!response.ok || payload.ok === false) {
+      return {
+        ok: false,
+        description: payload.description || `Telegram request failed with ${response.status}`,
+        payload,
+      };
+    }
+
+    return { ok: true, payload };
+  } catch (error) {
+    console.error('[Telegram] Failed to send message:', error);
+    return { ok: false, description: error.message || 'Failed to send Telegram message.' };
+  }
+}
+
+export async function sendTelegramMessageFromSettings(text) {
+  const settings = await TelegramSettings.findOne({ isEnabled: true }).lean();
+  if (!settings?.botToken || !settings?.chatId) {
+    return {
+      ok: false,
+      skipped: true,
+      description: 'Telegram notifications are disabled or incomplete.',
+    };
+  }
+
+  const botToken = decrypt(settings.botToken);
+  if (!botToken) {
+    return {
+      ok: false,
+      description: 'Failed to decrypt Telegram bot token.',
+    };
+  }
+
+  return sendTelegramMessage({
+    botToken,
+    chatId: settings.chatId,
+    text,
+  });
+}

--- a/src/models/PocketlyReminderSettings.js
+++ b/src/models/PocketlyReminderSettings.js
@@ -1,0 +1,43 @@
+import mongoose from 'mongoose';
+
+const PocketlyReminderSettingsSchema = new mongoose.Schema(
+  {
+    isEnabled: {
+      type: Boolean,
+      default: false,
+    },
+    reminderTime: {
+      type: String,
+      default: '21:00',
+    },
+    timezone: {
+      type: String,
+      default: 'Asia/Kolkata',
+    },
+    reminderMode: {
+      type: String,
+      enum: ['if_no_transactions', 'always'],
+      default: 'if_no_transactions',
+    },
+    lastReminderSentAt: {
+      type: Date,
+      default: null,
+    },
+    lastReminderSentDate: {
+      type: String,
+      default: null,
+    },
+  },
+  { timestamps: true }
+);
+
+PocketlyReminderSettingsSchema.statics.getSettings = async function () {
+  let settings = await this.findOne();
+  if (!settings) {
+    settings = await this.create({});
+  }
+  return settings;
+};
+
+export default mongoose.models.PocketlyReminderSettings ||
+  mongoose.model('PocketlyReminderSettings', PocketlyReminderSettingsSchema);

--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,6 @@
     {
       "path": "/api/cron/generate-summaries",
       "schedule": "0 2 * * *"
-    },
-    {
-      "path": "/api/cron/pocketly-reminder",
-      "schedule": "*/30 * * * *"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/generate-summaries",
       "schedule": "0 2 * * *"
+    },
+    {
+      "path": "/api/cron/pocketly-reminder",
+      "schedule": "*/30 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a scheduled Pocketly Telegram reminder cron endpoint
- add admin settings for reminder time, timezone, and reminder mode
- reuse a shared Telegram sender and improve the Pocketly settings mobile layout

## Verification
- node --check src/components/pocketly-tracker/FinanceSettingsTab.js
- node --check src/app/api/money/reminder-settings/route.js
- node --check src/app/api/cron/pocketly-reminder/route.js
- node --check src/lib/apps/pocketly/reminder.js