### PR TITLE
Redesign: ReCall app page

### DIFF
--- a/src/app/apps/recall/page.js
+++ b/src/app/apps/recall/page.js
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { Search, Plus, Trash2, Loader2, Sparkles, Pencil, Check, X } from 'lucide-react';
+import { Search, Plus, Trash2, Loader2, Sparkles, Pencil, Check, X, ArrowLeft, Brain } from 'lucide-react';
 import { SkeletonProvider, SkeletonWrapper } from 'react-skeletonify';
 import 'react-skeletonify/dist/index.css';
 import Link from 'next/link';
@@ -14,7 +14,7 @@ export default function RecallApp() {
         borderRadius: '12px',
         animationSpeed: 2,
         exceptTags: ['button', 'svg', 'img'],
-        background: '#e5e3d8',
+        background: '#d6e4dc',
       }}
     >
       <RecallContent />
@@ -38,7 +38,6 @@ function RecallContent() {
   const captureInputRef = useRef(null);
   const searchInputRef = useRef(null);
 
-  // Fetch recent memories on load
   useEffect(() => {
     fetchMemories();
   }, []);
@@ -72,7 +71,6 @@ function RecallContent() {
 
       if (res.ok) {
         const data = await res.json();
-        // Clear search if active to see the new memory
         if (searchQuery) {
           setSearchQuery('');
           await fetchMemories();
@@ -96,7 +94,7 @@ function RecallContent() {
     }
 
     setIsSearching(true);
-    setIsLoading(true); // Trigger skeleton for results
+    setIsLoading(true);
     try {
       const res = await fetch(`/api/recall/search?q=${encodeURIComponent(searchQuery)}`);
       if (res.ok) {
@@ -112,7 +110,6 @@ function RecallContent() {
   };
 
   const handleDelete = async (id) => {
-    // Optimistic update
     const previous = [...memories];
     setMemories(memories.filter((m) => m._id !== id));
 
@@ -121,7 +118,6 @@ function RecallContent() {
       if (!res.ok) throw new Error('Delete failed');
     } catch (error) {
       console.error('Failed to delete memory:', error);
-      // Revert optimistic update
       setMemories(previous);
     }
   };
@@ -176,172 +172,274 @@ function RecallContent() {
   };
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-8 lg:py-12">
-      {/* Header */}
-      <header className="mb-10 text-center flex flex-col items-center">
-        <Link
-          href="/apps"
-          className="self-start text-[#7c8e88] hover:text-[#1f644e] mb-4 flex items-center gap-2 transition-colors text-sm font-bold"
-        >
-          ← Back to Apps
-        </Link>
-        <h1 className="font-[family-name:var(--font-logo)] text-5xl text-[#1f644e] mb-3">ReCall</h1>
-        <p className="text-[#7c8e88] font-medium text-lg">
-          Your external memory. Throw it in, find it later.
-        </p>
-      </header>
-
-      {/* Capture Section */}
-      <section className="mb-12">
-        <form onSubmit={handleCapture} className="relative shadow-sm rounded-2xl">
-          <textarea
-            ref={captureInputRef}
-            value={captureText}
-            onChange={(e) => setCaptureText(e.target.value)}
-            placeholder="Throw in a thought, link, or idea instantly..."
-            className="w-full rounded-2xl border border-[#e5e3d8] bg-white p-5 pr-16 text-lg outline-none transition placeholder:text-[#a0b2ac] focus:border-[#1f644e] focus:ring-4 focus:ring-[#1f644e]/10 resize-none min-h-[120px]"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault();
-                handleCapture(e);
-              }
-            }}
-          />
-          <button
-            type="submit"
-            disabled={!captureText.trim() || isCapturing}
-            className="absolute bottom-4 right-4 bg-[#1f644e] text-white p-3 rounded-xl hover:bg-[#17503e] disabled:opacity-50 disabled:hover:bg-[#1f644e] transition-all cursor-pointer shadow-md"
+    <div
+      className="min-h-screen"
+      style={{ background: 'linear-gradient(160deg, #f7f9f7 0%, #eef3ef 100%)' }}
+    >
+      {/* Top nav bar */}
+      <nav className="sticky top-0 z-10 backdrop-blur-md border-b border-[#dde8e2]/60"
+        style={{ background: 'rgba(247,249,247,0.85)' }}>
+        <div className="max-w-3xl mx-auto px-5 h-14 flex items-center justify-between">
+          <Link
+            href="/apps"
+            className="flex items-center gap-2 text-[#5a756e] hover:text-[#1f644e] transition-colors text-sm font-semibold group"
           >
-            {isCapturing ? (
-              <Loader2 className="w-5 h-5 animate-spin" />
-            ) : (
-              <Plus className="w-5 h-5" />
-            )}
-          </button>
-        </form>
-      </section>
+            <ArrowLeft className="w-4 h-4 transition-transform group-hover:-translate-x-0.5" />
+            <span>Apps</span>
+          </Link>
 
-      {/* Search Section */}
-      <section className="mb-8">
-        <form onSubmit={handleSearch} className="relative">
-          <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
-            {isSearching ? (
-              <Loader2 className="w-5 h-5 text-[#1f644e] animate-spin" />
-            ) : (
-              <Sparkles className="w-5 h-5 text-[#1f644e]" />
-            )}
-          </div>
-          <input
-            ref={searchInputRef}
-            type="text"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="I remember the idea vaguely..."
-            className="w-full rounded-xl border-2 border-[#1f644e]/20 bg-white py-4 pl-12 pr-12 text-base font-medium outline-none transition placeholder:text-[#7c8e88] focus:border-[#1f644e] focus:ring-4 focus:ring-[#1f644e]/10"
-          />
-          {searchQuery && (
-            <button
-              type="button"
-              onClick={clearSearch}
-              className="absolute inset-y-0 right-0 pr-4 flex items-center text-[#7c8e88] hover:text-[#1e3a34] cursor-pointer"
+          <div className="flex items-center gap-2">
+            <div
+              className="w-7 h-7 rounded-lg flex items-center justify-center"
+              style={{ background: '#1f644e' }}
             >
-              <X className="w-5 h-5" />
-            </button>
-          )}
-        </form>
-      </section>
+              <Brain className="w-3.5 h-3.5 text-white" />
+            </div>
+            <span className="text-sm font-bold text-[#1a3530] tracking-tight">ReCall</span>
+          </div>
 
-      {/* Feed / Results Section */}
-      <section>
-        <div className="flex items-center justify-between mb-4 px-1">
-          <h2 className="text-sm font-bold uppercase tracking-wider text-[#7c8e88]">
-            {searchQuery ? 'Search Results' : 'Recent Memories'}
-          </h2>
-          <span className="text-xs font-bold text-[#b0bfba]">{memories.length} items</span>
+          <div className="w-16" />
         </div>
+      </nav>
 
-        <SkeletonWrapper loading={isLoading && memories.length === 0}>
-          <div className="space-y-4">
-            {!isLoading && memories.length === 0 ? (
-              <div className="text-center py-12 border-2 border-dashed border-[#e5e3d8] rounded-2xl bg-white/50">
-                <Sparkles className="w-8 h-8 mx-auto text-[#c8d8d0] mb-3" />
-                <p className="text-[#7c8e88] font-medium">
-                  {searchQuery
-                    ? 'No memories match that thought.'
-                    : 'Your memory bank is empty. Start capturing above!'}
+      <main className="max-w-3xl mx-auto px-5 py-10 lg:py-14">
+        {/* Hero header */}
+        <header className="mb-12 text-center">
+          <div
+            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold mb-5 tracking-wide"
+            style={{ background: '#e0ede8', color: '#1f644e' }}
+          >
+            <Sparkles className="w-3 h-3" />
+            <span>AI-Powered Memory</span>
+          </div>
+          <h1
+            className="text-5xl lg:text-6xl font-bold mb-4 tracking-tight leading-none"
+            style={{
+              fontFamily: "'Playfair Display', serif",
+              color: '#0f2922',
+            }}
+          >
+            Re<span style={{ color: '#1f644e' }}>Call</span>
+          </h1>
+          <p className="text-[#5a756e] text-lg leading-relaxed max-w-md mx-auto">
+            Your external memory — throw in a thought, find it later with semantic search.
+          </p>
+        </header>
+
+        {/* Capture card */}
+        <section className="mb-8">
+          <div
+            className="rounded-2xl border border-[#dde8e2] shadow-sm overflow-hidden"
+            style={{ background: '#ffffff' }}
+          >
+            <form onSubmit={handleCapture}>
+              <textarea
+                ref={captureInputRef}
+                value={captureText}
+                onChange={(e) => setCaptureText(e.target.value)}
+                placeholder="Throw in a thought, link, or idea…"
+                className="w-full px-5 pt-5 pb-3 text-base outline-none resize-none min-h-[110px] placeholder:text-[#a8bdb7] text-[#1a3530] leading-relaxed"
+                style={{ background: 'transparent' }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    handleCapture(e);
+                  }
+                }}
+              />
+              <div className="flex items-center justify-between px-4 py-3 border-t border-[#f0f5f2]">
+                <p className="text-xs text-[#a8bdb7] font-medium">
+                  Press <kbd className="font-semibold">Enter</kbd> to save
                 </p>
-              </div>
-            ) : (
-              memories.map((memory) => (
-                <div
-                  key={memory._id}
-                  className="group border border-[#e5e3d8] bg-white rounded-2xl p-5 hover:border-[#c8d8d0] hover:shadow-sm transition-all"
+                <button
+                  type="submit"
+                  disabled={!captureText.trim() || isCapturing}
+                  className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-bold text-white transition-all disabled:opacity-40 cursor-pointer shadow-sm active:scale-95"
+                  style={{ background: '#1f644e' }}
+                  onMouseEnter={(e) => { if (!e.currentTarget.disabled) e.currentTarget.style.background = '#17503e'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.background = '#1f644e'; }}
                 >
-                  {editingId === memory._id ? (
-                    <div className="flex flex-col gap-3">
-                      <textarea
-                        value={editText}
-                        onChange={(e) => setEditText(e.target.value)}
-                        className="w-full rounded-xl border border-[#e5e3d8] bg-[#fcfbf5] p-3 text-[#1e3a34] outline-none focus:border-[#1f644e] min-h-[100px] resize-y"
-                        autoFocus
-                      />
-                      <div className="flex justify-end gap-2">
-                        <button
-                          onClick={cancelEditing}
-                          className="px-4 py-2 text-sm font-bold text-[#7c8e88] hover:bg-[#f0f5f2] rounded-xl transition-colors cursor-pointer"
-                        >
-                          Cancel
-                        </button>
-                        <button
-                          onClick={() => handleUpdate(memory._id)}
-                          disabled={isUpdating || !editText.trim()}
-                          className="flex items-center gap-2 px-4 py-2 text-sm font-bold bg-[#1f644e] text-white rounded-xl hover:bg-[#17503e] disabled:opacity-50 transition-colors cursor-pointer"
-                        >
-                          {isUpdating ? (
-                            <Loader2 className="w-4 h-4 animate-spin" />
-                          ) : (
-                            <Check className="w-4 h-4" />
-                          )}
-                          Save
-                        </button>
-                      </div>
-                    </div>
+                  {isCapturing ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
                   ) : (
-                    <>
-                      <div className="whitespace-pre-wrap text-[#1e3a34] leading-relaxed mb-4 text-[15px]">
-                        {memory.text}
-                      </div>
-                      <div className="flex items-center justify-between mt-4 pt-4 border-t border-[#f0f5f2]">
-                        <span className="text-xs font-semibold text-[#a0b2ac]">
-                          {formatDate(memory.createdAt)}
-                          {memory.score && ` • ${(memory.score * 100).toFixed(0)}% match`}
-                        </span>
+                    <Plus className="w-4 h-4" />
+                  )}
+                  Capture
+                </button>
+              </div>
+            </form>
+          </div>
+        </section>
 
-                        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+        {/* Search bar */}
+        <section className="mb-10">
+          <form onSubmit={handleSearch} className="relative group">
+            <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+              {isSearching ? (
+                <Loader2 className="w-4 h-4 text-[#1f644e] animate-spin" />
+              ) : (
+                <Sparkles className="w-4 h-4 text-[#8aaba4]" />
+              )}
+            </div>
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search memories semantically…"
+              className="w-full rounded-xl border border-[#dde8e2] bg-white py-3.5 pl-11 pr-12 text-sm font-medium outline-none transition-all placeholder:text-[#a8bdb7] text-[#1a3530]"
+              style={{
+                boxShadow: '0 1px 3px rgba(31,100,78,0.06)',
+              }}
+              onFocus={(e) => {
+                e.currentTarget.style.borderColor = '#1f644e';
+                e.currentTarget.style.boxShadow = '0 0 0 3px rgba(31,100,78,0.1)';
+              }}
+              onBlur={(e) => {
+                e.currentTarget.style.borderColor = '#dde8e2';
+                e.currentTarget.style.boxShadow = '0 1px 3px rgba(31,100,78,0.06)';
+              }}
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={clearSearch}
+                className="absolute inset-y-0 right-0 pr-4 flex items-center text-[#8aaba4] hover:text-[#1f644e] transition-colors cursor-pointer"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </form>
+        </section>
+
+        {/* Feed */}
+        <section>
+          <div className="flex items-center justify-between mb-5">
+            <h2 className="text-xs font-bold uppercase tracking-widest text-[#8aaba4]">
+              {searchQuery ? 'Search Results' : 'Recent Memories'}
+            </h2>
+            <span
+              className="text-xs font-bold px-2.5 py-1 rounded-full"
+              style={{ background: '#e0ede8', color: '#1f644e' }}
+            >
+              {memories.length}
+            </span>
+          </div>
+
+          <SkeletonWrapper loading={isLoading && memories.length === 0}>
+            <div className="space-y-3">
+              {!isLoading && memories.length === 0 ? (
+                <div
+                  className="text-center py-16 rounded-2xl border-2 border-dashed border-[#dde8e2]"
+                  style={{ background: 'rgba(255,255,255,0.5)' }}
+                >
+                  <div
+                    className="w-12 h-12 rounded-2xl flex items-center justify-center mx-auto mb-4"
+                    style={{ background: '#e0ede8' }}
+                  >
+                    <Brain className="w-6 h-6" style={{ color: '#1f644e' }} />
+                  </div>
+                  <p className="text-[#5a756e] font-medium text-sm">
+                    {searchQuery
+                      ? 'No memories match that query.'
+                      : 'Your memory bank is empty — start capturing above!'}
+                  </p>
+                </div>
+              ) : (
+                memories.map((memory, i) => (
+                  <article
+                    key={memory._id}
+                    className="group rounded-xl border border-[#dde8e2] bg-white transition-all hover:border-[#b8d4c8] hover:shadow-md"
+                    style={{ animationDelay: `${i * 30}ms` }}
+                  >
+                    {editingId === memory._id ? (
+                      <div className="p-5 flex flex-col gap-3">
+                        <textarea
+                          value={editText}
+                          onChange={(e) => setEditText(e.target.value)}
+                          className="w-full rounded-xl border border-[#dde8e2] px-4 py-3 text-sm text-[#1a3530] outline-none min-h-[100px] resize-y leading-relaxed"
+                          style={{
+                            background: '#f7fbf9',
+                          }}
+                          onFocus={(e) => {
+                            e.currentTarget.style.borderColor = '#1f644e';
+                            e.currentTarget.style.boxShadow = '0 0 0 3px rgba(31,100,78,0.1)';
+                          }}
+                          onBlur={(e) => {
+                            e.currentTarget.style.borderColor = '#dde8e2';
+                            e.currentTarget.style.boxShadow = 'none';
+                          }}
+                          autoFocus
+                        />
+                        <div className="flex justify-end gap-2">
                           <button
-                            onClick={() => startEditing(memory)}
-                            className="p-2 text-[#7c8e88] hover:text-[#1f644e] hover:bg-[#f0f5f2] rounded-lg transition-colors cursor-pointer"
-                            title="Edit"
+                            onClick={cancelEditing}
+                            className="px-4 py-2 text-sm font-semibold text-[#5a756e] hover:text-[#1a3530] rounded-lg transition-colors cursor-pointer"
                           >
-                            <Pencil className="w-4 h-4" />
+                            Cancel
                           </button>
                           <button
-                            onClick={() => handleDelete(memory._id)}
-                            className="p-2 text-[#7c8e88] hover:text-[#c94c4c] hover:bg-red-50 rounded-lg transition-colors cursor-pointer"
-                            title="Delete"
+                            onClick={() => handleUpdate(memory._id)}
+                            disabled={isUpdating || !editText.trim()}
+                            className="flex items-center gap-2 px-4 py-2 text-sm font-bold text-white rounded-lg transition-all disabled:opacity-40 cursor-pointer active:scale-95"
+                            style={{ background: '#1f644e' }}
+                            onMouseEnter={(e) => { if (!e.currentTarget.disabled) e.currentTarget.style.background = '#17503e'; }}
+                            onMouseLeave={(e) => { e.currentTarget.style.background = '#1f644e'; }}
                           >
-                            <Trash2 className="w-4 h-4" />
+                            {isUpdating ? (
+                              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                            ) : (
+                              <Check className="w-3.5 h-3.5" />
+                            )}
+                            Save
                           </button>
                         </div>
                       </div>
-                    </>
-                  )}
-                </div>
-              ))
-            )}
-          </div>
-        </SkeletonWrapper>
-      </section>
+                    ) : (
+                      <div className="p-5">
+                        <p className="whitespace-pre-wrap text-[#1a3530] leading-relaxed text-sm mb-5">
+                          {memory.text}
+                        </p>
+                        <div className="flex items-center justify-between pt-3 border-t border-[#f0f5f2]">
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs font-medium text-[#a8bdb7]">
+                              {formatDate(memory.createdAt)}
+                            </span>
+                            {memory.score && (
+                              <span
+                                className="text-xs font-bold px-2 py-0.5 rounded-full"
+                                style={{ background: '#e0ede8', color: '#1f644e' }}
+                              >
+                                {(memory.score * 100).toFixed(0)}% match
+                              </span>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                            <button
+                              onClick={() => startEditing(memory)}
+                              className="p-2 rounded-lg text-[#8aaba4] hover:text-[#1f644e] hover:bg-[#f0f7f4] transition-all cursor-pointer"
+                              title="Edit"
+                            >
+                              <Pencil className="w-3.5 h-3.5" />
+                            </button>
+                            <button
+                              onClick={() => handleDelete(memory._id)}
+                              className="p-2 rounded-lg text-[#8aaba4] hover:text-[#b84040] hover:bg-red-50 transition-all cursor-pointer"
+                              title="Delete"
+                            >
+                              <Trash2 className="w-3.5 h-3.5" />
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </article>
+                ))
+              )}
+            </div>
+          </SkeletonWrapper>
+        </section>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## ReCall Page Redesign

Complete visual redesign of `/apps/recall` with a premium, editorial aesthetic:

### Changes
- **New layout**: Sticky frosted-glass top navbar with back arrow + app icon/name, replacing the inline header back link
- **Hero header**: Refined pill badge, large serif display title with green accent, softer subtext
- **Capture card**: White card with transparent textarea, bottom toolbar row showing keyboard hint + styled submit button
- **Search bar**: Cleaner input with subtle box-shadow focus ring and animated icon states
- **Memory feed**: Refined cards with tighter spacing, match score pill badge, hover-revealed action buttons
- **Empty state**: Icon-centered empty state card with branded styling
- **Color palette**: Forest green (`#1f644e`), sage muted tones (`#5a756e`, `#8aaba4`), warm white background gradient — all preserved from brand

All functionality (capture, search, edit, delete, optimistic updates) is preserved unchanged.