### PR TITLE
fix: resolve multiple Attenda app bugs

### DIFF
--- a/src/components/attenda/AnalyticsTab.js
+++ b/src/components/attenda/AnalyticsTab.js
@@ -101,9 +101,13 @@ export default function AnalyticsTab() {
               </p>
             </div>
             <div className="text-center p-2 bg-[#fcfbf5] rounded-lg">
-              <p className="text-lg font-bold text-[#1e3a34]">{stats?.remainingDays ?? 0}</p>
+              <p className="text-lg font-bold text-[#1e3a34]">
+                {stats?.remainingDays !== null && stats?.remainingDays !== undefined
+                  ? stats.remainingDays
+                  : '—'}
+              </p>
               <p className="text-[10px] font-bold uppercase tracking-wider text-[#7c8e88]">
-                Remaining
+                Remaining Days
               </p>
             </div>
             <div className="text-center p-2 bg-[#fcfbf5] rounded-lg">
@@ -258,9 +262,13 @@ export default function AnalyticsTab() {
             </p>
           </div>
           <div className="text-center">
-            <p className="text-xl font-bold text-[#1e3a34]">{stats?.totalWorkingDays ?? 0}</p>
+            <p className="text-xl font-bold text-[#1e3a34]">
+              {stats?.remainingDays !== null && stats?.remainingDays !== undefined
+                ? `${stats.presentDays + stats.absentDays} / ${stats.presentDays + stats.absentDays + stats.remainingDays}`
+                : (stats?.totalWorkingDays ?? 0)}
+            </p>
             <p className="text-[10px] font-bold uppercase tracking-wider text-[#7c8e88]">
-              Days Logged
+              Total / Remaining
             </p>
           </div>
           <div className="text-center">

--- a/src/components/attenda/SemesterTab.js
+++ b/src/components/attenda/SemesterTab.js
@@ -178,7 +178,14 @@ export default function SemesterTab() {
               className="rounded-xl border border-[#e5e3d8] bg-white overflow-hidden"
             >
               <button
-                onClick={() => setExpandedDay(isExpanded ? null : dayIdx)}
+                onClick={() => {
+                  if (isExpanded) {
+                    setExpandedDay(null);
+                  } else {
+                    setExpandedDay(dayIdx);
+                    setNewSlot({ subjectId: '', startTime: '09:00', endTime: '10:00' });
+                  }
+                }}
                 className="w-full flex items-center justify-between p-3 text-left cursor-pointer hover:bg-[#fcfbf5] transition-colors"
               >
                 <span className="text-sm font-bold text-[#1e3a34]">{dayName}</span>
@@ -272,6 +279,7 @@ export default function SemesterTab() {
                           },
                         ];
                         updateTimetableSlots(dayIdx, updatedSlots);
+                        setNewSlot({ subjectId: '', startTime: '09:00', endTime: '10:00' });
                       }}
                       disabled={!newSlot.subjectId}
                       className="p-1.5 bg-[#1f644e] text-white rounded-lg hover:bg-[#17503e] transition-colors disabled:opacity-50 cursor-pointer"

--- a/src/components/attenda/TodayTab.js
+++ b/src/components/attenda/TodayTab.js
@@ -107,7 +107,8 @@ export default function TodayTab() {
     return result;
   }, [activeSemester, allDays, holidaysSet]);
 
-  // Was today already saved?
+  // Was today already saved? Sync with context changes (e.g. saved from Calendar tab).
+  // Only re-run when context data changes — NOT on isSaved changes (to avoid overriding Edit).
   useEffect(() => {
     const existing = getTodayStatus();
     if (existing) {
@@ -128,7 +129,7 @@ export default function TodayTab() {
       });
       setLectureStatuses(initial);
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [getTodayStatus, todaysLectures]);
 
   // Pre-fill when timetable loads and no existing day saved
   useEffect(() => {

--- a/src/lib/attenda/calculations.js
+++ b/src/lib/attenda/calculations.js
@@ -80,13 +80,41 @@ export function computeCollegeAttendance(semester, semesterDays, holidays) {
   const total = presentDays + absentDays;
   const percentage = total > 0 ? (presentDays / total) * 100 : null;
 
+  // Calculate remaining working days if semester has an end date
+  let remainingDays = null;
+  if (semester.endDate) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const end = new Date(semester.endDate + 'T00:00:00');
+    const weeklyHolidays = semester.weeklyHolidays || [];
+
+    if (end >= today) {
+      let count = 0;
+      const current = new Date(today);
+      while (current <= end) {
+        const dayOfWeek = current.getDay();
+        if (!weeklyHolidays.includes(dayOfWeek)) {
+          const dk = formatDateKey(current);
+          // Skip declared holidays
+          if (!holidaySet.has(dk)) {
+            count++;
+          }
+        }
+        current.setDate(current.getDate() + 1);
+      }
+      remainingDays = count;
+    } else {
+      remainingDays = 0;
+    }
+  }
+
   return {
     presentDays,
     absentDays,
     totalWorkingDays: total,
     allWorkingDays: total,
     percentage: percentage !== null ? Math.round(percentage * 100) / 100 : null,
-    remainingDays: null, // null = unknown (semester dates not set)
+    remainingDays,
   };
 }
 


### PR DESCRIPTION
- Calculate remainingDays properly when semester has end date
- Show "—" instead of 0 when remainingDays is unknown
- Fix duplicate Days Logged stat in Analytics summary
- Reset timetable form state when switching days and after adding slots
- Sync TodayTab isSaved state with context changes (e.g. saves from Calendar)
- Fix Edit button being overridden by effect dependency issue