### PR TITLE
feat: register Attenda app in mini-apps config

### DIFF
--- a/src/config/miniApps.js
+++ b/src/config/miniApps.js
@@ -59,4 +59,12 @@ export const MINI_APPS = [
     category: 'Productivity',
     iconSrc: '/images/apps/kanban.png',
   },
+  {
+    id: 'attenda',
+    name: 'Attenda',
+    tagline: 'Track your college attendance. Mark days, view analytics, predict safe bunks.',
+    href: '/apps/attenda',
+    category: 'Productivity',
+    iconSrc: '/images/apps/attenda.png',
+  },
 ];


### PR DESCRIPTION
Attenda was missing from the mini-apps registry so it did not show up on the `/apps` page or `/admin/apps/store` page.

**Changes:**
- Added Attenda entry to `src/config/miniApps.js` under Productivity category
- Links to `/apps/attenda`

Both public `/apps` page and admin App Store already read from this config, so no other changes needed.